### PR TITLE
#125: Improve compose files examples

### DIFF
--- a/docker-compose.yml.apache_dist
+++ b/docker-compose.yml.apache_dist
@@ -6,7 +6,7 @@ services:
     depends_on:
       - mysql
 #      - mongodb
-    environment:
+#    environment:
 #      PHP_XDEBUG_ENABLED: 0
 #      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
 #      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254

--- a/docker-compose.yml.fpm_dist
+++ b/docker-compose.yml.fpm_dist
@@ -6,7 +6,7 @@ services:
     depends_on:
       - mysql
 #      - mongodb
-    environment:
+#    environment:
 #      PHP_XDEBUG_ENABLED: 0
 #      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
 #      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254
@@ -50,7 +50,7 @@ services:
   nginx:
     image: carcel/akeneo-nginx
     depends_on:
-      - akeneo-behat
+      - akeneo
     ports:
       - '8080:80'
     volumes:
@@ -61,7 +61,7 @@ services:
   nginx-behat:
     image: carcel/akeneo-behat-nginx
     depends_on:
-      - akeneo
+      - akeneo-behat
     ports:
       - '8081:80'
     volumes:


### PR DESCRIPTION
Fix mistakes on compose files examples:
- `environment` option has no value in akeneo service, as all are commented, so it sould be commented too
- `nginx` and `nginx-behat` services depends `akeneo-behat` and `akeneo` respectively, when it should be the opposite.