### PR TITLE
Closes #125 - Fix carcel/fpm image 

### DIFF
--- a/docker-compose.yml.apache_dist
+++ b/docker-compose.yml.apache_dist
@@ -6,7 +6,7 @@ services:
     depends_on:
       - mysql
 #      - mongodb
-    environment:
+#    environment:
 #      PHP_XDEBUG_ENABLED: 0
 #      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
 #      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254

--- a/docker-compose.yml.fpm_dist
+++ b/docker-compose.yml.fpm_dist
@@ -6,7 +6,7 @@ services:
     depends_on:
       - mysql
 #      - mongodb
-    environment:
+#    environment:
 #      PHP_XDEBUG_ENABLED: 0
 #      PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY
 #      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254
@@ -50,7 +50,7 @@ services:
   nginx:
     image: carcel/akeneo-nginx
     depends_on:
-      - akeneo-behat
+      - akeneo
     ports:
       - '8080:80'
     volumes:
@@ -61,7 +61,7 @@ services:
   nginx-behat:
     image: carcel/akeneo-behat-nginx
     depends_on:
-      - akeneo
+      - akeneo-behat
     ports:
       - '8081:80'
     volumes:

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -21,6 +21,9 @@ RUN sed -i "s/user = www-data/user = docker/" /etc/php/7.1/fpm/pool.d/www.conf &
     sed -i "s/listen.owner = www-data/listen.owner = docker/" /etc/php/7.1/fpm/pool.d/www.conf && \
     sed -i "s/listen.group = www-data/listen.group = docker/" /etc/php/7.1/fpm/pool.d/www.conf
 
+# Create PHP run directory
+RUN mkdir /run/php
+
 # Define "docker" as current user
 USER docker
 


### PR DESCRIPTION
`carcel/fpm` image (and those using it) with PHP 7.1 failed to launch, because php-fpm7.1 process needs the folder `/run/php`, which do not exist.

The folder is now created after php-fpm installation and configuration.