### PR TITLE
Issue 200: Fix XDebug activation and deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2017-05-11
+
+### Bug fix
+
+- **Issue 200:** Fix XDebug activation/deactivation.
+
 ## 2017-05-08
 
 ### Enhancement

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
             /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
 
-# Configure PHP
+# Configure PHP Apache
 RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php5/apache2/php.ini && \
     sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php5/apache2/php.ini && \
     sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php5/apache2/php.ini && \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -23,14 +23,10 @@ RUN sed -i "s/user = www-data/user = docker/" /etc/php5/fpm/pool.d/www.conf && \
     sed -i "s/listen.owner = www-data/listen.owner = docker/" /etc/php5/fpm/pool.d/www.conf && \
     sed -i "s/listen.group = www-data/listen.group = docker/" /etc/php5/fpm/pool.d/www.conf
 
-# Configure PHP FPM
 RUN sed -i "s/listen = .*/listen = 9001/" /etc/php5/fpm/pool.d/www.conf
-
-# Expose PHP FPM
-EXPOSE 9001
 
 # Define "docker" as current user
 USER docker
 
-# Run apache in foreground
+# Run FPM in foreground
 CMD ["sudo", "php5-fpm", "-F"]

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -35,6 +35,12 @@ RUN apt-get update && \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
             /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
 
+# Configure PHP CLI
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php5/cli/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 2G/" /etc/php5/cli/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php5/cli/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php5/cli/php.ini
+
 # Add a "docker" user
 RUN useradd docker --shell /bin/bash --create-home \
   && usermod --append --groups sudo docker \
@@ -45,13 +51,7 @@ RUN useradd docker --shell /bin/bash --create-home \
 RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN chmod +x /usr/local/bin/composer
 
-RUN php5enmod mcrypt && php5dismod xdebug
-
-RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php5/cli/php.ini && \
-    sed -i "s/memory_limit = .*/memory_limit = 2G/" /etc/php5/cli/php.ini && \
-    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php5/cli/php.ini && \
-    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php5/cli/php.ini
-
+# Copy "entrypoint"
 COPY ./files/entrypoint.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/entrypoint.sh
 

--- a/php/files/entrypoint.sh
+++ b/php/files/entrypoint.sh
@@ -35,7 +35,11 @@ fi
 if [ ! -z "${PHP_XDEBUG_ENABLED}" ]; then
     if [ "${PHP_XDEBUG_ENABLED}" == "1" ]; then
         execAsRoot "php5enmod xdebug"
+    elif [ "${PHP_XDEBUG_ENABLED}" == "0" ]; then
+        execAsRoot "php5dismod xdebug"
     fi
+else
+    execAsRoot "php5dismod xdebug"
 fi
 
 eval "${@}"


### PR DESCRIPTION
Relates to #200.

Xdebug can be activated by setting the environment variable `PHP_XDEBUG_ENABLED` to 1, and deactivated by setting it to 0 or omitting it.

Activation worked fine, but deactivation was effective only for PHP CLI, and didn't work for FPM and Apache.