### PR TITLE
Closes #226 - Fix composer home in compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Issue 199:** Remove `carcel/akeneo-fpm` from PHP 5.6 and 7.0.
     Remove `carcel/akeneo-apache` from PHP 7.0 and following.
+- **Issue 226:** Set composer home folder in compose file and better document composer settings.
 - **Issue 234:** Remove `carcel/nginx` image (official `nginx` image is to be used instead).
 
 ## 2017-06-13

--- a/Docs/akeneo/compose.md
+++ b/Docs/akeneo/compose.md
@@ -10,5 +10,5 @@ Two compose file examples are provided, both providing two environments, one for
     - you can access the full documentation regarding this compose file [here](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/akeneo/mod_php.md).
     
 - [**The second one**](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/akeneo/docker-compose.yml.fpm_dist) provides nginx + PHP-FPM:
-    - it uses [`carcel/akeneo-fpm`](https://hub.docker.com/r/carcel/akeneo-fpm/) and  [`carcel/nginx`](https://hub.docker.com/r/carcel/nginx/),
+    - it uses [`carcel/akeneo-fpm`](https://hub.docker.com/r/carcel/akeneo-fpm/) and  [`nginx`](https://hub.docker.com/_/nginx/),
     - you can access the full documentation regarding this compose file [here](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/akeneo/fpm.md).

--- a/Docs/akeneo/docker-compose.yml.apache_dist
+++ b/Docs/akeneo/docker-compose.yml.apache_dist
@@ -11,7 +11,8 @@ services:
       - selenium
     environment:
       BEHAT_TMPDIR: /home/docker/pim/app/cache/tmp    # Mandatory to run behat tests
-      PHP_IDE_CONFIG: 'serverName=pim'             # Mandatory for debugging
+      COMPOSER_HOME: /home/docker/.composer
+      PHP_IDE_CONFIG: 'serverName=pim'                # Mandatory for debugging
       PHP_XDEBUG_ENABLED: 0                           # [optional] This is the default value, change to 1 to enable Xdebug
       PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY              # [optional] This is the default value
       PHP_XDEBUG_REMOTE_HOST: xxx.xxx.xxx.xxx         # Replace with you host IP (only for Windows and Mac as Linux uses socket)

--- a/Docs/akeneo/docker-compose.yml.apache_dist
+++ b/Docs/akeneo/docker-compose.yml.apache_dist
@@ -23,8 +23,9 @@ services:
     user: docker
     volumes:
       - ./:/home/docker/pim
-      - ~/.composer:/home/docker/.composer
-      - /tmp/behat/screenshots:/tmp/behat/screenshots
+      - ~/.config/composer:/home/docker/.composer
+      - ~/.ssh:/home/docker/.ssh                        # [optional] Only needed for projects using Akeneo EE standard edition
+      - /tmp/behat/screenshots:/tmp/behat/screenshots   # Needed to be able to access behat screenshots when scenarios are failing
     working_dir: /home/docker/pim
     networks:
       - akeneo

--- a/Docs/akeneo/docker-compose.yml.fpm_dist
+++ b/Docs/akeneo/docker-compose.yml.fpm_dist
@@ -20,8 +20,9 @@ services:
     user: docker
     volumes:
       - ./:/srv/pim
-      - ~/.composer:/home/docker/.composer
-      - /tmp/behat/screenshots:/tmp/behat/screenshots
+      - ~/.config/composer:/home/docker/.composer
+      - ~/.ssh:/home/docker/.ssh                        # [optional] Only needed for projects using Akeneo EE standard edition
+      - /tmp/behat/screenshots:/tmp/behat/screenshots   # Needed to be able to access behat screenshots when scenarios are failing
     working_dir: /srv/pim
     networks:
       - akeneo

--- a/Docs/akeneo/docker-compose.yml.fpm_dist
+++ b/Docs/akeneo/docker-compose.yml.fpm_dist
@@ -10,7 +10,8 @@ services:
       - mongodb-behat
       - selenium
     environment:
-      BEHAT_TMPDIR: /srv/pim/app/cache/tmp    # Mandatory to run behat tests
+      BEHAT_TMPDIR: /srv/pim/app/cache/tmp            # Mandatory to run behat tests
+      COMPOSER_HOME: /home/docker/.composer
       PHP_IDE_CONFIG: 'serverName=pim-cli'            # Mandatory for debugging
       PHP_XDEBUG_ENABLED: 0                           # [optional] This is the default value, change to 1 to enable Xdebug
       PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY              # [optional] This is the default value

--- a/Docs/getting-started.md
+++ b/Docs/getting-started.md
@@ -46,23 +46,23 @@ networks:     # Here we define a network, in which everything that happen in the
 
 services:     # Each service you define below will be a container. It allows you to define you container configuration in a clear, readable way
   apache:     # This is our Apache + PHP container (as `mod_php` package needs both `php` and `apache` package, everything is in one container)
-    image: carcel/apache-php:latest         # We use the image `carcel/apache` in its latest version to create the container
+    image: carcel/apache-php:latest                 # We use the image `carcel/apache` in its latest version to create the container
     depends_on:
-      - mysql                               # This container will depend on the MySQL on, meaning it won't start until MySQL container is
-    ports:
-      - '8080:80'                           # Here we map the ports: port 80 of the container will be redirected on port 8080 on your machine
-    user: docker                            # Every command we execute in the container will be as the `docker` user (id 1000 group 1000, defined during the build of the image `carcel/apache`)
+      - mysql                                       # This container will depend on the MySQL on, meaning it won't start until MySQL container is
+    ports:  
+      - '8080:80'                                   # Here we map the ports: port 80 of the container will be redirected on port 8080 on your machine
+    user: docker                                    # Every command we execute in the container will be as the `docker` user (id 1000 group 1000, defined during the build of the image `carcel/apache`)
     volumes:
-      - ./:/home/docker/application         # We map the content of the current folder (usually your PHP application) with `/home/docker/application` (because `carcel/apache` contains a vhost pointing to this location)
-      - ~/.composer:/home/docker/.composer  # Same thing with you own composer folder, allowing you to use your own composer cache and GitHub token when running `composer update` for instance
-    working_dir: /home/docker/application   # The default working directory, so if for instance you run `app/console cache:clear` with `docker-compose`, it will be in this folder
+      - ./:/home/docker/application                 # We map the content of the current folder (usually your PHP application) with `/home/docker/application` (because `carcel/apache` contains a vhost pointing to this location)
+      - ~/.config/composer:/home/docker/.composer   # Same thing with you own composer folder, allowing you to use your own composer cache and GitHub token when running `composer update` for instance
+    working_dir: /home/docker/application           # The default working directory, so if for instance you run `app/console cache:clear` with `docker-compose`, it will be in this folder
     networks:
-      - symfony                             # The Docker network we want our application to run within.
+      - symfony                                     # The Docker network we want our application to run within.
 
   mysql:
-    image: mysql:5.7                        # Here we use the official MySQL 5.7 image: https://hub.docker.com/_/mysql/
-    environment:                            # We can provide some environment variables to the container when we start it
-      - MYSQL_ROOT_PASSWORD=root            # Here they are used to initialize MySQL with a root password and a default database
+    image: mysql:5.7                                # Here we use the official MySQL 5.7 image: https://hub.docker.com/_/mysql/
+    environment:                                    # We can provide some environment variables to the container when we start it
+      - MYSQL_ROOT_PASSWORD=root                    # Here they are used to initialize MySQL with a root password and a default database
       - MYSQL_USER=symfony
       - MYSQL_PASSWORD=symfony
       - MYSQL_DATABASE=symfony

--- a/Docs/getting-started.md
+++ b/Docs/getting-started.md
@@ -49,6 +49,8 @@ services:     # Each service you define below will be a container. It allows you
     image: carcel/apache-php:latest                 # We use the image `carcel/apache` in its latest version to create the container
     depends_on:
       - mysql                                       # This container will depend on the MySQL on, meaning it won't start until MySQL container is
+    environment:
+      COMPOSER_HOME: /home/docker/.composer         # Ensure the composer home folder will be where we expect it for volume sharing
     ports:  
       - '8080:80'                                   # Here we map the ports: port 80 of the container will be redirected on port 8080 on your machine
     user: docker                                    # Every command we execute in the container will be as the `docker` user (id 1000 group 1000, defined during the build of the image `carcel/apache`)
@@ -73,3 +75,9 @@ services:     # Each service you define below will be a container. It allows you
 You can notice than the mapping of the ports or of the volumes works the same way: first you provide the one of your own machine, then in second you provide the one of the Docker container.
 
 By mapping the port 80 of the container `apache` to your port 8080, you can access the PHP application in your web browser at the URL `localhost:8080` (you can of course choose another port).
+
+### Special note about composer
+
+In the above example, the composer home folder inside the container is ensured to be `/home/docker/composer` and shared with your own host machine.
+If you have not installed `composer` on your host machine, then you can choose whatever folder you want.
+However, if you have and use `composer` on your host, then check first where this home folder is. You can find more information in [composer documentation](https://getcomposer.org/doc/03-cli.md#composer-home) about it.

--- a/Docs/symfony/compose.md
+++ b/Docs/symfony/compose.md
@@ -10,5 +10,5 @@ Two compose file examples are provided:
     - you can access the full documentation regarding this compose file [here](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/symfony/mod_php.md).
     
 - [**The second one**](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/symfony/docker-compose.yml.fpm_dist) provides nginx + PHP-FPM:
-    - it uses [`carcel/fpm`](https://hub.docker.com/r/carcel/fpm/) and  [`carcel/nginx`](https://hub.docker.com/r/carcel/nginx/),
+    - it uses [`carcel/fpm`](https://hub.docker.com/r/carcel/fpm/) and  [`nginx`](https://hub.docker.com/_/nginx/),
     - you can access the full documentation regarding this compose file [here](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/symfony/fpm.md).

--- a/Docs/symfony/docker-compose.yml.apache_dist
+++ b/Docs/symfony/docker-compose.yml.apache_dist
@@ -6,6 +6,7 @@ services:
     depends_on:
       - mysql
     environment:
+      COMPOSER_HOME: /home/docker/.composer
       PHP_IDE_CONFIG: 'serverName=your-key'           # Mandatory for debugging
       PHP_XDEBUG_ENABLED: 0                           # [optional] This is the default value, change to 1 to enable Xdebug
       PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY              # [optional] This is the default value

--- a/Docs/symfony/docker-compose.yml.fpm_dist
+++ b/Docs/symfony/docker-compose.yml.fpm_dist
@@ -6,6 +6,7 @@ services:
     depends_on:
       - mysql
     environment:
+      COMPOSER_HOME: /home/docker/.composer
       PHP_IDE_CONFIG: 'serverName=your-cli-key'       # Mandatory for debugging in CLI
       PHP_XDEBUG_ENABLED: 0                           # [optional] This is the default value, change to 1 to enable Xdebug
       PHP_XDEBUG_IDE_KEY: XDEBUG_IDE_KEY              # [optional] This is the default value

--- a/Docs/symfony/docker-compose.yml.fpm_dist
+++ b/Docs/symfony/docker-compose.yml.fpm_dist
@@ -21,7 +21,7 @@ services:
       - symfony
 
   nginx:
-    image: carcel/nginx
+    image: nginx
     depends_on:
       - fpm
     environment:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Four branches are maintained, all based on [debian:jessie](https://hub.docker.co
 ## How to use these images?
 
 If you are new to Docker, please start with the [getting started section](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/getting-started.md).
+And even if you are not new, it is a good start to understand how these images are intended to be used.
 
 Then, you can find out how to use these images
 - for Symfony development in the [Symfony docker-compose section](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/symfony/compose.md).

--- a/akeneo-fpm/README.md
+++ b/akeneo-fpm/README.md
@@ -2,7 +2,7 @@
 
 This is a Docker development environment for Akeneo PIM with PHP FPM, based on [carcel/fpm](https://hub.docker.com/r/carcel/fpm).
 
-It is configured to listen to the port 9001, and is intended to be used with [carcel/akeneo-nginx](https://hub.docker.com/r/carcel/akeneo-nginx).
+It is configured to listen to the port 9001, and is intended to be used with [nginx](https://hub.docker.com/_/nginx).
 
 ## How to use it?
 


### PR DESCRIPTION
## Description

This PR adds the composer home folder as environment variable in the compose file. This ensures it is always set correctly and that cache will be correctly accessible in the container.

Documentation is also added to explain why it is needed to map the composer home folder of the host machine to the container.

### Bonus

This PR also removes some omissions in documentation after removing `carcel/nginx` image.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #226, #234
`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
