### PR TITLE
Issue 254: Clear webpack created folders before install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2017-06-24
+
+### Enhancement
+
+- **Issue 254:** Clear folders created by webpack (`web/cache` and `web/dist`) before PIM install.
+
 ## 2017-06-17
 
 ### Enhancement

--- a/akeneo-fpm/files/pim-assets.sh
+++ b/akeneo-fpm/files/pim-assets.sh
@@ -3,7 +3,9 @@
 echo "Clean previous assets"
 rm -rf app/cache/*
 rm -rf web/bundles/*
+rm -rf web/cache/*
 rm -rf web/css/*
+rm -rf web/dist/*
 rm -rf web/js/*
 
 echo "Initialize assets"

--- a/akeneo-fpm/files/pim-initialize.sh
+++ b/akeneo-fpm/files/pim-initialize.sh
@@ -6,7 +6,9 @@ rm -rf app/cache/*
 rm -rf app/file_storage/*
 rm -rf app/logs/*
 rm -rf web/bundles/*
+rm -rf web/cache/*
 rm -rf web/css/*
+rm -rf web/dist/*
 rm -rf web/js/*
 rm -rf web/media/*
 


### PR DESCRIPTION
## Description

Two new folders are created by webpack during the install process: `web/dist` and `web/cache`. These folders need to be cleared before new initializations.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #254

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
