### PR TITLE
Issue 260: Move images from `carcel` to `akeneo`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 | Feature request?       | yes/no
 | BC Break report?       | yes/no
 | RFC?                   | yes/no
-| Affected image and tag | carcel/image:tag
+| Affected image and tag | akeneo/image:tag
 
 <!--
 - Please replace this comment by the description of your issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2017-06-26
+
+### Enhancement
+
+- **Issue 260:** Move images from namespace `carcel` to `akeneo`
+
 ## 2017-06-17
 
 ### Enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ These Dockerfiles are not only made for my personal use, but for anybody who lik
 
 I gladly accept any contributions: fixing typos, glitches, bugs, technical enhancements and new features.
 
-For technical enhancements and new features, please first have a look at [current issues](https://github.com/damien-carcel/Dockerfiles/issues).
+For technical enhancements and new features, please first have a look at [current issues](https://github.com/akeneo/Dockerfiles/issues).
 There may already be one, with details and ideas on how to implement it. You are welcome to pick it and propose a pull request if you'd like.
 
 If it does not already exist, please first open an issue to describe and discuss what you want to do, it will ease the merge of your pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Damien Carcel
+Copyright (c) 2017 Akeneo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,30 +2,28 @@
 
 This repository contains the Dockerfiles I use for Akeneo and other Symfony development. Feel free to use/adapt them if they fit your needs.
 
-| [Master][Master] | [php-7.1][php-7.1] | [php-7.0][php-7.0] | [php-5.6][php-5.6] |
+| [Master][Master] | [php-7.1][php-7.1] | [php-5.6][php-5.6] |
 |:----------------:|:----------:|:----------:|:----------:|
-| [![Build status][Master image]][Master] | [![Build status][php-7.1 image]][php-7.1] | [![Build status][php-7.0 image]][php-7.0] | [![Build status][php-5.6 image]][php-5.6] |
+| [![Build status][Master image]][Master] | [![Build status][php-7.1 image]][php-7.1] | [![Build status][php-5.6 image]][php-5.6] |
 
-  [Master image]: https://travis-ci.org/damien-carcel/Dockerfiles.svg?branch=master
-  [Master]: https://travis-ci.org/damien-carcel/Dockerfiles/tree/master
-  [php-7.1 image]: https://travis-ci.org/damien-carcel/Dockerfiles.svg?branch=php-7.1
-  [php-7.1]: https://travis-ci.org/damien-carcel/Dockerfiles/tree/php-7.1
-  [php-7.0 image]: https://travis-ci.org/damien-carcel/Dockerfiles.svg?branch=php-7.0
-  [php-7.0]: https://travis-ci.org/damien-carcel/Dockerfiles/tree/php-7.0
-  [php-5.6 image]: https://travis-ci.org/damien-carcel/Dockerfiles.svg?branch=php-5.6
-  [php-5.6]: https://travis-ci.org/damien-carcel/Dockerfiles/tree/php-5.6
+  [Master image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=master
+  [Master]: https://travis-ci.org/akeneo/Dockerfiles/tree/master
+  [php-7.1 image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-7.1
+  [php-7.1]: https://travis-ci.org/akeneo/Dockerfiles/tree/php-7.1
+  [php-5.6 image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-5.6
+  [php-5.6]: https://travis-ci.org/akeneo/Dockerfiles/tree/php-5.6
 
 ## Images available
 
-- [**carcel/php**](php/README.md): Base image with PHP CLI preconfigured, based on `debian:jessie-slim`
-- [**carcel/fpm**](fpm/README.md): An image with PHP FPM preconfigured to be use with any Symfony project, based on `carcel/php`
-- [**carcel/apache-php**](apache-php/README.md): An image with Apache + mod_php preconfigured to be use with any Symfony project, based on `carcel/php`
-- [**carcel/akeneo-apache**](akeneo-apache/README.md): An image for Akeneo development with Apache + `mod_php`, based on `carcel/apache-php`
+- [**akeneo/php**](php/README.md): Base image with PHP CLI preconfigured, based on `debian:jessie-slim`
+- [**akeneo/fpm**](fpm/README.md): An image with PHP FPM preconfigured to be use with any Symfony project, based on `akeneo/php`
+- [**akeneo/apache-php**](apache-php/README.md): An image with Apache + mod_php preconfigured to be use with any Symfony project, based on `akeneo/php`
+- [**akeneo/akeneo-apache**](akeneo-apache/README.md): An image for Akeneo development with Apache + `mod_php`, based on `akeneo/apache-php`
 
 ## How to use these images?
 
-Find out how to use these images with `docker-compose` [here](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/compose.md).
+Find out how to use these images with `docker-compose` [here](https://github.com/akeneo/Dockerfiles/blob/master/Docs/getting-started.md).
 
 ## License
 
-This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/damien-carcel/Dockerfiles/blob/master/LICENSE) file.
+This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/akeneo/Dockerfiles/blob/master/LICENSE) file.

--- a/akeneo-apache/Dockerfile
+++ b/akeneo-apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM carcel/apache-php:php-5.6
+FROM akeneo/apache-php:php-5.6
 MAINTAINER Damien Carcel <damien.carcel@gmail.com>
 
 # Define "root" as current user

--- a/akeneo-apache/README.md
+++ b/akeneo-apache/README.md
@@ -2,16 +2,16 @@
 
 This is a Docker development environment for Akeneo PIM with Apache and `mod_php`.
 
-This environment is based on [carcel/apache-php](https://hub.docker.com/r/carcel/apache-php/).
+This environment is based on [akeneo/apache-php](https://hub.docker.com/r/akeneo/apache-php/).
 
 ## How to use it?
 
 ### From Docker hub
 
-You can directly pull this image from [Docker hub](https://hub.docker.com/r/carcel/akeneo-apache/) by running:
+You can directly pull this image from [Docker hub](https://hub.docker.com/r/akeneo/akeneo-apache/) by running:
 
 ```bash
-$ docker run --name akeneo -p 8080:80 -d carcel/akeneo-apache:php-5.6
+$ docker run --name akeneo -p 8080:80 -d akeneo/akeneo-apache:php-5.6
 ```
 
 Access the URL `localhost:8080` with your web browser to check that the container works.
@@ -32,8 +32,8 @@ $ docker run --name akeneo -p 8080:80 -d akeneo-apache
 
 ### Use this image with Docker Compose
 
-The easiest way to use these images is [Docker Compose](https://docs.docker.com/compose/). You can found detailed explanations [here](https://github.com/damien-carcel/Dockerfiles/blob/master/Docs/compose.md).
+The easiest way to use these images is [Docker Compose](https://docs.docker.com/compose/). You can found detailed explanations [here](https://github.com/akeneo/Dockerfiles/blob/master/Docs/akeneo/compose.md).
 
 ## License
 
-This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/damien-carcel/Dockerfiles/blob/master/LICENSE) file.
+This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/akeneo/Dockerfiles/blob/master/LICENSE) file.

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -1,4 +1,4 @@
-FROM carcel/php:5.6
+FROM akeneo/php:5.6
 MAINTAINER Damien Carcel <damien.carcel@gmail.com>
 
 # Define "root" as current user

--- a/apache-php/README.md
+++ b/apache-php/README.md
@@ -1,6 +1,6 @@
 # Apache and PHP on Docker
 
-This is a basic Docker environment for PHP development, based on [carcel/php](https://hub.docker.com/r/carcel/php).
+This is a basic Docker environment for PHP development, based on [akeneo/php](https://hub.docker.com/r/akeneo/php).
 
 It is not intended to use directly as it stands, but rather to extend it and create custom development environments.
 
@@ -13,10 +13,10 @@ The environment come with  some PHP extensions: apcu, mcrypt, intl, mysql, curl,
 
 ### From Docker hub
 
-You can directly pull this image from [Docker hub](https://hub.docker.com/r/carcel/apache-php/) by running:
+You can directly pull this image from [Docker hub](https://hub.docker.com/r/akeneo/apache-php/) by running:
 
 ```bash
-$ docker run --name apache-php -p 8080:80 -d carcel/apache-php:php-5.6
+$ docker run --name apache-php -p 8080:80 -d akeneo/apache-php:php-5.6
 ```
 
 Access the URL `localhost:8080` with your web browser to check that the container works.
@@ -37,4 +37,4 @@ $ docker run --name apache-php -p 8080:80 -d apache-php
 
 ## License
 
-This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/damien-carcel/Dockerfiles/blob/master/LICENSE) file.
+This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/akeneo/Dockerfiles/blob/master/LICENSE) file.

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM carcel/php:5.6
+FROM akeneo/php:5.6
 MAINTAINER Damien Carcel <damien.carcel@gmail.com>
 
 # Define "root" as current user

--- a/fpm/README.md
+++ b/fpm/README.md
@@ -1,6 +1,6 @@
 # PHP FPM on Docker
 
-This is a basic Docker environment for PHP FPM development, based on [carcel/php](https://hub.docker.com/r/carcel/php).
+This is a basic Docker environment for PHP FPM development, based on [akeneo/php](https://hub.docker.com/r/akeneo/php).
 
 It is not intended to use directly as it stands, but rather to extend it and create custom development environments.
 
@@ -12,10 +12,10 @@ The PHP FPM daemon is configured with "docker" as user and group, and listen to 
 
 ### From Docker hub
 
-You can directly pull this image from [Docker hub](https://hub.docker.com/r/carcel/apache-php/) by running:
+You can directly pull this image from [Docker hub](https://hub.docker.com/r/akeneo/apache-php/) by running:
 
 ```bash
-$ docker run -p 8080:80 -d --name fpm carcel/fpm:5.6
+$ docker run -p 8080:80 -d --name fpm akeneo/fpm:5.6
 ```
 
 Access the URL `localhost:8080` with your web browser to check that the container works.
@@ -37,4 +37,4 @@ $ docker run --name fpm -d fpm
 
 ## License
 
-This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/damien-carcel/Dockerfiles/blob/master/LICENSE) file.
+This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/akeneo/Dockerfiles/blob/master/LICENSE) file.

--- a/php/README.md
+++ b/php/README.md
@@ -8,4 +8,4 @@ The environment comes with native Debian Jessie PHP 5.6, and some PHP extensions
 
 ## License
 
-This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/damien-carcel/Dockerfiles/blob/master/LICENSE) file.
+This repository is under the MIT license. See the complete license in the [LICENSE](https://github.com/akeneo/Dockerfiles/blob/master/LICENSE) file.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,5 +7,5 @@ cwd=$(pwd)
 for (( i=0; i<${#images[@]}; i++ ));
 do
     cd ${cwd}/${images[i]}
-    docker build -t carcel/${images[i]}:${versions[i]} .
+    docker build -t akeneo/${images[i]}:${versions[i]} .
 done


### PR DESCRIPTION
## Description

These images have been moved https://github.com/damien-carcel to https://github.com/akeneo. Consequently, their namespace has to be changed from `carcel` to `akeneo`.

This is the first step before configuring https://hub.docker.com/r/akeneo/.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #260

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
