### PR TITLE
Issue 243: Updating images to Debian Stretch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2017-06-27
+
+### Enhancement
+
+- **Issue 243:** Update branches `php-7.1` and `master` to `debian:stretch-lite`.
+
 ## 2017-06-26
 
 ### Enhancement

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the Dockerfiles I use for Akeneo and other Symfony deve
 
 ## Images available
 
-- [**akeneo/php**](php/README.md): Base image with PHP CLI preconfigured, based on `debian:jessie-slim`
+- [**akeneo/php**](php/README.md): Base image with PHP CLI preconfigured, based on `debian:stretch-slim`
 - [**akeneo/fpm**](fpm/README.md): An image with PHP FPM preconfigured to be use with any Symfony project, based on `akeneo/php`
 - [**akeneo/apache-php**](apache-php/README.md): An image with Apache + mod_php preconfigured to be use with any Symfony project, based on `akeneo/php`
 - [**akeneo/akeneo-fpm**](akeneo-fpm/README.md): An image for Akeneo development with PHP FPM, based on `akeneo/fpm`

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 MAINTAINER Damien Carcel <damien.carcel@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -16,19 +16,6 @@ RUN apt-get update && \
 # Add PHP 7.1 repository
 RUN wget -O sury.gpg https://packages.sury.org/php/apt.gpg && apt-key add sury.gpg && rm sury.gpg
 COPY files/sury.list /etc/apt/sources.list.d/sury.list
-
-# Install and configure Gosu
-RUN set -x && \
-    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.9/gosu-amd64" && \
-    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.9/gosu-amd64.asc" && \
-    export GNUPGHOME="$(mktemp -d)" && \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
-    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \
-    chmod +x /usr/local/bin/gosu && \
-    gosu nobody true && \
-    chown root:users /usr/local/bin/gosu && \
-    chmod +s /usr/local/bin/gosu
 
 # Install PHP with some extensions
 RUN apt-get update && \

--- a/php/files/entrypoint.sh
+++ b/php/files/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 XDEBUG_PATH="/etc/php/7.1/mods-available/xdebug.ini"
 
 function execAsRoot {
-    gosu root bash -c "$1"
+    sudo bash -c "$1"
 }
 
 function writeXdebugSetting {

--- a/php/files/sury.list
+++ b/php/files/sury.list
@@ -1,1 +1,1 @@
-deb https://packages.sury.org/php/ jessie main
+deb https://packages.sury.org/php/ stretch main


### PR DESCRIPTION
## Description

Now that Debian Stretch is out, we can use it!

This also makes possible to remove [GoSu](https://github.com/tianon/gosu), as using `sudo` in the entrypoint works fine with Stretch.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #243

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
