### PR TITLE
Issue 243: Add GnuPG to `carcel/php` 

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -6,8 +6,8 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install some useful packages
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        apt-transport-https ca-certificates bash-completion less curl wget sudo \
-        mysql-client mongodb-clients ssh-client vim git imagemagick perceptualdiff && \
+        apt-transport-https bash-completion ca-certificates curl git gnupg imagemagick \
+        less mongodb-clients mysql-client perceptualdiff ssh-client sudo vim wget && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \


### PR DESCRIPTION
## Description

GnuPG is not present in stretch image (it was on Jessie) and we need it to be able to use Sury repository.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | -
| Documentation                     | -
| Fixed tickets                     | #243

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
