### PR TITLE
Issue 280: Add `mbstring` to PHP 7.0 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 2017-07-17
 
-### Enhancement
+### Bug fix
+
+- **Issue 280:** Add `mbstring` extension to PHP 7.0 images.
+
+## 2017-07-17
+
+### Enhancements
 
 - **Issue 265:** Remove `akeneo/akeneo-apache` image.
                  Remove usage of `gosu` in PHP 5.6 images.

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 # Install PHP with some extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mcrypt \
+        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mbstring php7.0-mcrypt \
         php7.0-mongo php7.0-mysql php7.0-soap php7.0-xdebug php7.0-xml php7.0-zip && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
## Description

`mbstring` extension was missing in PHP 7.0 images (present in PHP 5.6 and PHP 7.1), and is required for PHP API client.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #280
`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
