### PR TITLE
Issue 284: Move all versions in master branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,7 @@
 <!--
 - Please fill in this template according to the PR you're about to submit.
 - Replace this comment by a description of what your PR is solving.
-- Bug fixes must be submitted against the lowest branch where they apply
-  (lowest branches are regularly merged to upper ones so they get the fixes too):
-  for example apply on `php-5.6` branch, it will then be merged in `php-7.0`, and so on up to `master`.
-- Documentation must be submitted against the master branch (it is not present in other branches to ease its maintenance).
+- Bug fixes must be submitted against all needed PHP version in the same pull request.
 -->
 
 ## Definition Of Done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: bash
 services: docker
+env:
+  - TAG=5.6
+  - TAG=7.0
+  - TAG=7.1
 
 script:
-  - ./run_tests.sh
+  - ./run_tests.sh 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,204 +1,210 @@
 # Changelog
 
-## 2017-07-17
+## 2017-08-18
 
 ### Enhancement
 
-- **Issue 265:** Remove `akeneo/akeneo-apache` and `akeneo/akeneo-fpm` images.
+- **Issue 284**: Move all images tags on master branch.
+
+## 2017-07-17
+
+### Enhancements
+
+- **Issue 265**: Remove `akeneo/akeneo-apache` and `akeneo/akeneo-fpm` images.
                  Remove usage of `gosu` in PHP 5.6 images.
-- **Issue 277:** Bring back PHP 7.0 images.
+- **Issue 277**: Bring back PHP 7.0 images.
 
 ## 2017-06-27
 
 ### Enhancement
 
-- **Issue 243:** Update branches `php-7.1` and `master` to `debian:stretch-lite`.
+- **Issue 243**: Update branches `php-7.1` and `master` to `debian:stretch-lite`.
 
 ## 2017-06-26
 
 ### Enhancement
 
-- **Issue 260:** Move images from namespace `carcel` to `akeneo`.
+- **Issue 260**: Move images from namespace `carcel` to `akeneo`.
 
 ## 2017-06-24
 
 ### Enhancement
 
-- **Issue 254:** Clear folders created by webpack (`web/cache` and `web/dist`) before PIM install.
+- **Issue 254**: Clear folders created by webpack (`web/cache` and `web/dist`) before PIM install.
 
 ## 2017-06-19
 
 ### Documentation
 
-- **Issue 251:** Fix Akeneo FPM compose file indentation.
+- **Issue 251**: Fix Akeneo FPM compose file indentation.
 
 ## 2017-06-17
 
 ### Documentation
 
-- **Issue 224:** Add usage of NodeJS and NPM in the Akeneo FPM compose file.
-- **Issue 225:** Update compose file for Akeneo FPM, to be used with MySQL 5.7 and Elasticsearch 5.x (no more MongoDB).
-- **Issue 226:** Set composer home folder in compose file and better document composer settings.
+- **Issue 224**: Add usage of NodeJS and NPM in the Akeneo FPM compose file.
+- **Issue 225**: Update compose file for Akeneo FPM, to be used with MySQL 5.7 and Elasticsearch 5.x (no more MongoDB).
+- **Issue 226**: Set composer home folder in compose file and better document composer settings.
 
 ### Enhancements
 
-- **Issue 199:** Remove `carcel/akeneo-fpm` from PHP 5.6 and 7.0.
+- **Issue 199**: Remove `carcel/akeneo-fpm` from PHP 5.6 and 7.0.
     Remove `carcel/akeneo-apache` from PHP 7.0 and following.
-- **Issue 234:** Remove `carcel/nginx` image (official `nginx` image is to be used instead).
+- **Issue 234**: Remove `carcel/nginx` image (official `nginx` image is to be used instead).
 
 ## 2017-06-13
 
 ### Documentation
 
-- **Issue 132:** Adds CONTRIBUTING.md and GitHub templates (issues and pull requests).
+- **Issue 132**: Adds CONTRIBUTING.md and GitHub templates (issues and pull requests).
 
 ## 2017-06-05
 
 ### Enhancement
 
-- **Issue 216:** Fuse `carcel/akeneo` and `carcel/akeneo-behat` into `carcel/akeneo-apache`.
+- **Issue 216**: Fuse `carcel/akeneo` and `carcel/akeneo-behat` into `carcel/akeneo-apache`.
 
 ## 2017-05-22
 
 ### Enhancement
 
-- **Issue 212:** Add `bcmath` extension to PHP 7.x images
+- **Issue 212**: Add `bcmath` extension to PHP 7.x images
 
 ## 2017-05-11
 
 ### Bug fix
 
-- **Issue 200:** Fix XDebug activation/deactivation.
+- **Issue 200**: Fix XDebug activation/deactivation.
 
 ## 2017-05-08
 
 ### Enhancements
 
-- **Issue 185:** Make the vhosts and nginx servers more generic.
+- **Issue 185**: Make the vhosts and nginx servers more generic.
     All base images now expect the web application to be in `/home/docker/application`,
     and Akeneo images in `/home/docker/pim`.
-- **Issue 188:** Increase nginx client max body size to 20 MB (like for FPM).
+- **Issue 188**: Increase nginx client max body size to 20 MB (like for FPM).
 
 ## 2017-04-26
 
 ### Enhancement
 
-- **Issue 187:** Add MySQL and MongoDB clients (available for all images).
+- **Issue 187**: Add MySQL and MongoDB clients (available for all images).
 
 ## 2017-03-04
 
 ### Enhancement
 
-- **Issue 179:** Manage "test" environment in the helpers (`pim-cac`, `pim-assets`, `pim-initialize`) of Akeneo images.
+- **Issue 179**: Manage "test" environment in the helpers (`pim-cac`, `pim-assets`, `pim-initialize`) of Akeneo images.
 
 ## 2017-02-25
 
 ### Documentation
 
-- **Issue 160:** Improve the documentation for people who have none or very few knowledge of Docker.
+- **Issue 160**: Improve the documentation for people who have none or very few knowledge of Docker.
 
 ## 2017-02-23
 
 ### Bug fix
 
-- **Issue 167:** Set `date.timezone` to `Etc/UTC` instead of `Europe/Paris`.
+- **Issue 167**: Set `date.timezone` to `Etc/UTC` instead of `Europe/Paris`.
 
 ### Enhancement
 
-- **Issue 168:** Rename asset script into `pim-assets`.
+- **Issue 168**: Rename asset script into `pim-assets`.
 
 ## 2017-02-14
 
 ### Enhancement
 
-- **Issue 141:** Make `apache-php` image usable as it is.
+- **Issue 141**: Make `apache-php` image usable as it is.
     Application is now placed in `/home/docker/symfony` in the containers.
 
 ## 2017-02-13
 
 ### Bug fixes
 
-- **Issue 154:** Minor fixes in compose examples.
-- **Issue 155:** Removes all caches in `akeneo-fpm` image.
+- **Issue 154**: Minor fixes in compose examples.
+- **Issue 155**: Removes all caches in `akeneo-fpm` image.
 
 ## 2017-02-12
 
 ### Enhancements
 
-- **Issue 31:** Use `debian:jessie-slim` as base image,
+- **Issue 31**: Use `debian:jessie-slim` as base image,
     and perform the same cleaning on documentation after package installation.
-- **Issue 66:** Remove npm and grunt from akeneo images
+- **Issue 66**: Remove npm and grunt from akeneo images
     (use dedicated images for that, like [digitallyseamless](https://hub.docker.com/u/digitallyseamless/) images).
-- **Issue 115:** Configure `carcel/fpm` to use port 9001 instead of socket
+- **Issue 115**: Configure `carcel/fpm` to use port 9001 instead of socket
     and remove images `carcel/akeneo-nginx` and `carcel/akeneo-behat-nginx`.
-- **Issue 116:** Remove `carcel/akeneo-behat-fpm` image.
-- **Issue 131:** Replace Dotdeb repositories by Sury ones for php-7.0 images.
+- **Issue 116**: Remove `carcel/akeneo-behat-fpm` image.
+- **Issue 131**: Replace Dotdeb repositories by Sury ones for php-7.0 images.
 
 ## 2017-02-05
 
 ### Documentation
 
-- **Issue 124:** Complete the documentation and put it on master only.
+- **Issue 124**: Complete the documentation and put it on master only.
 
 ## 2017-01-21
 
 ### Bug fix
 
-- **Issue 125:** Fix wrong path for FPM PID/socket in `carcel/fpm`, for `php-7.1` and `master` branches.
+- **Issue 125**: Fix wrong path for FPM PID/socket in `carcel/fpm`, for `php-7.1` and `master` branches.
 
 ## 2017-01-05
 
 ### Enhancement
 
-- **Issue 24:** Add a basic CI on Travis (ensure all images can be built before merge).
+- **Issue 24**: Add a basic CI on Travis (ensure all images can be built before merge).
 
 ## 2016-12-21
 
 ### Bug fix
 
-- **Issue 110:** Add missing "user" option in compose files.
+- **Issue 110**: Add missing "user" option in compose files.
 
 ### Enhancements
 
-- **Issue 106:** Enhance compose examples and documentation.
-- **Issue 108:** Enhance helper commands.
+- **Issue 106**: Enhance compose examples and documentation.
+- **Issue 108**: Enhance helper commands.
 
 ## 2016-12-18
 
 ### Bug fix
 
-- **Issue 75:** Allow to properly restart apache container by removing `/var/run/apache2/apache2.pid` in
+- **Issue 75**: Allow to properly restart apache container by removing `/var/run/apache2/apache2.pid` in
     `carcel/apache-php` image entry point. 
 
 ### Enhancements
 
-- **Issue 99:** Deactivate Xdebug by default.
-- **Issue 100:** Add a script to easily perform "cache:clear" on Akeneo. Assets are also dumped as symlinks now.
+- **Issue 99**: Deactivate Xdebug by default.
+- **Issue 100**: Add a script to easily perform "cache:clear" on Akeneo. Assets are also dumped as symlinks now.
 
 ## 2016-12-12
 
 ### Enhancements
 
-- **Issue 88:** Allow user to config Xdebug from environment variables.
-- **Issue 89:** Introduce `php-7.1` branch containing PHP 7.1 based images.
+- **Issue 88**: Allow user to config Xdebug from environment variables.
+- **Issue 89**: Introduce `php-7.1` branch containing PHP 7.1 based images.
     PHP 7.1 packages are provided by [Sury](https://packages.sury.org//) repositories. Master is updated to PHP 7.1 too.
     
 ## 2016-12-05
 
 ### Enhancement
 
-- **Issue 74:** Add a default Xdebug configuration in `carcel/php` image.
+- **Issue 74**: Add a default Xdebug configuration in `carcel/php` image.
 
 ## 2016-11-28
 
 ### Bug fixes
 
-- **Issue 62:** Improve package install and cleaning.
-- **Issue 68:** Update compose documentation.
+- **Issue 62**: Improve package install and cleaning.
+- **Issue 68**: Update compose documentation.
 
 ### Enhancement
 
-- **Issue 66:** Add npm and grunt on akeneo development images (needed to run JavaScript and CSS static analysis).
+- **Issue 66**: Add npm and grunt on akeneo development images (needed to run JavaScript and CSS static analysis).
 
 ## 2016-11-21
 
@@ -210,49 +216,49 @@
 
 ### Bug fix
 
-- **Issue 35:** Add missing `php7.0-mbstring` package.
+- **Issue 35**: Add missing `php7.0-mbstring` package.
 
 ## 2016-10-31
 
 ### Documentation
 
-- **Issue 53:** Reorganize documentation (minimalist READMEs, all important documentation in `COMPOSE.md`).
+- **Issue 53**: Reorganize documentation (minimalist READMEs, all important documentation in `COMPOSE.md`).
 
 ## 2016-10-22
 
 ### Bug fixes
 
-- **Issue 51:** Fix an issue when running behat tests (add missing environment variable and volume sharing in compose
+- **Issue 51**: Fix an issue when running behat tests (add missing environment variable and volume sharing in compose
     examples).
-- **Issue 52:** Add `perceptualdiff` package in behat images (required to run Akeneo Enterprise Edition behats).
+- **Issue 52**: Add `perceptualdiff` package in behat images (required to run Akeneo Enterprise Edition behats).
 
 ## 2016-10-15
 
 ### Enhancements
 
-- **Issue 22:** Add `carcel/akeneo-fpm` and `carcel/akeneo-behat-fpm` images (based on `carcel/fpm`),
+- **Issue 22**: Add `carcel/akeneo-fpm` and `carcel/akeneo-behat-fpm` images (based on `carcel/fpm`),
     and `carcel/akeneo-nginx` and `carcel/akeneo-behat-nginx` (based on `carcel/nginx`).
-- **Issue 23:** Add `carcel/nginx` image.
+- **Issue 23**: Add `carcel/nginx` image.
 
 ### Bug fixes
 
-- **Issue 34:** Fix user declaration in Dockerfiles by placing it at the end.
-- **Issue 36:** Raise PHP upload size limit to 20 MB.
-- **Issue 37:** Fix Selenium container usage in compose file example.
-- **Issue 45:** Fix an issue with composer installation during `carcel/php` image build.
+- **Issue 34**: Fix user declaration in Dockerfiles by placing it at the end.
+- **Issue 36**: Raise PHP upload size limit to 20 MB.
+- **Issue 37**: Fix Selenium container usage in compose file example.
+- **Issue 45**: Fix an issue with composer installation during `carcel/php` image build.
 
 ## 2016-10-09
 
 ### Enhancements
 
-- **Issue 5:** Add `carcel/fpm` image (extends `carcel/php`). Introduce a new docker compose file example dedicated to FPM.
-- **Issue 20:** Split `carcel/apache-php` image to introduce a new `carcel/php` image (the first one extends the second).
+- **Issue 5**: Add `carcel/fpm` image (extends `carcel/php`). Introduce a new docker compose file example dedicated to FPM.
+- **Issue 20**: Split `carcel/apache-php` image to introduce a new `carcel/php` image (the first one extends the second).
 
 ## 2016-10-08
 
 ### Enhancement
 
-- **Issue 4:** Introduce `php-7.0` branch, containing PHP 7.0 based images.
+- **Issue 4**: Introduce `php-7.0` branch, containing PHP 7.0 based images.
     PHP 7.0 packages are provided by [Dotdeb](https://www.dotdeb.org/) repositories.
     Master contains the same PHP 7.0 images.
     Original PHP 5.6 images (Debian Jessie native packages) are now in the `php-5.6` branch.
@@ -262,7 +268,7 @@
 
 ### Enhancement
 
-- **Issue 13:** Add images `carcel/akeneo` and `carcel/akeneo-behat`.
+- **Issue 13**: Add images `carcel/akeneo` and `carcel/akeneo-behat`.
     These new images extends the original one, which is now known as `carcel/apache-php` image.
     Each image is in its own subfolder, with its own README. A compose file example was added.
 
@@ -276,13 +282,13 @@
 
 ### Enhancement
 
-- **Issue 6:** Run only Apache daemon as foreground process. MySQL and MongoDB are removed and to be launched in other containers.
+- **Issue 6**: Run only Apache daemon as foreground process. MySQL and MongoDB are removed and to be launched in other containers.
 
 ## 2016-08-22
 
 ### Enhancement
 
-- **Issue 1:** Add imagemagick and its php extension.
+- **Issue 1**: Add imagemagick and its php extension.
 
 ## Initial commit (2016-08-15)
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,32 @@
 # Akeneo Dockerfiles
 
+[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg?branch=master)](https://travis-ci.org/akeneo/Dockerfiles)
+
 This repository contains the Dockerfiles we use for Akeneo PIM and other PHP or Symfony development/testing. Feel free to use/adapt them if they fit your needs.
 
 **These images do not contain Akeneo PIM**.
 
-| [Master][Master] | [php-7.1][php-7.1] | [php-7.0][php-7.0] | [php-5.6][php-5.6] |
-|:----------------:|:------------------:|:------------------:|:------------------:|
-| [![Build status][Master image]][Master] | [![Build status][php-7.1 image]][php-7.1] | [![Build status][php-7.0 image]][php-7.0] | [![Build status][php-5.6 image]][php-5.6] |
-
-  [Master image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=master
-  [Master]: https://travis-ci.org/akeneo/Dockerfiles/tree/master
-  [php-7.1 image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-7.1
-  [php-7.1]: https://travis-ci.org/akeneo/Dockerfiles/tree/php-7.1
-  [php-7.0 image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-7.0
-  [php-7.0]: https://travis-ci.org/akeneo/Dockerfiles/tree/php-7.0
-  [php-5.6 image]: https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-5.6
-  [php-5.6]: https://travis-ci.org/akeneo/Dockerfiles/tree/php-5.6
-
 ## Images available
 
-- [**akeneo/php**](php/README.md): Base image with PHP CLI preconfigured, based on `debian:stretch-slim`
-- [**akeneo/fpm**](fpm/README.md): An image with PHP FPM preconfigured to be used with any PHP project, based on `akeneo/php`
+- [**akeneo/php**](php/README.md): Base image with PHP CLI preconfigured, based on `debian:jessie-slim` or `debian:stretch-slim`
+- [**akeneo/fpm**](fpm/README.md): An image with PHP FPM preconfigured to be used with any PHP project, based on `akeneo/php` (needs to be run along `nginx` or `httpd`)
 - [**akeneo/apache-php**](apache-php/README.md): An image with Apache + mod_php preconfigured to be used with any PHP project, based on `akeneo/php`
 
-## GitHub branches and corresponding Docker Hub tags
+All images are available as follow:
 
-Four branches are maintained, all based on [debian:jessie](https://hub.docker.com/_/debian/):
+| PHP version | Based on                                                                                     | Corresponding tags        |
+|-------------|----------------------------------------------------------------------------------------------|---------------------------|
+| 5.6         | Debian 8 "Jessie" with native PHP package                                                    | akeneo/php:5.6            |
+|             |                                                                                              | akeneo/fpm:php-5.6        |
+|             |                                                                                              | akeneo/apache-php:php-5.6 |
+| 7.0         | Debian 9 "Stretch" with native PHP packages                                                  | akeneo/php:7.0            |
+|             |                                                                                              | akeneo/fpm:php-7.0        |
+|             |                                                                                              | akeneo/apache-php:php-7.0 |
+| 7.1         | Debian 9 "Stretch" with packages coming from [Ondřej Surý repository](https://deb.sury.org/) | akeneo/php:7.1            |
+|             |                                                                                              | akeneo/fpm:php-7.1        |
+|             |                                                                                              | akeneo/apache-php:php-7.1 |
 
-- `php-5.6` branch provides images with native Jessie PHP 5.6. Corresponding tag is `php-5.6`, except for `akeneo/php` and `akeneo/fpm` images, which simply use the tag `5.6`.
-- `php-7.1` branch provides images with PHP 7.1 from [Sury](https://deb.sury.org/) repository. Corresponding tag is `php-7.1`, except for `akeneo/php` and `akeneo/fpm` images, which simply use the tag `7.1`.
-- `master` branch images correspond to the tag `latest`, and are exactly the same than images with `php-7.1` tag.
+For all images, images tagged `latest` are identical to those using the most recent PHP version.
 
 **Please, remember that, for the moment, only Apache + mod_php, with PHP 5.6, is officially supported by Akeneo.**
 

--- a/apache-php/5.6/Dockerfile
+++ b/apache-php/5.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM akeneo/php:7.1
+FROM akeneo/php:5.6
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
 # Define "root" as current user
@@ -6,19 +6,19 @@ USER root
 
 # Install Apache + mod_php and some PHP extensions
 RUN apt-get update && \
-    apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php7.1 && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php5 && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
             /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
 
 # Configure PHP Apache
-RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php/7.1/apache2/php.ini && \
-    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/7.1/apache2/php.ini && \
-    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php/7.1/apache2/php.ini && \
-    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php/7.1/apache2/php.ini
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php5/apache2/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php5/apache2/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php5/apache2/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php5/apache2/php.ini
 
-RUN phpdismod xdebug
+RUN php5dismod xdebug
 
 # Configure Apache
 RUN a2enmod rewrite && \

--- a/apache-php/5.6/files/apache-foreground
+++ b/apache-php/5.6/files/apache-foreground
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+rm -f /var/run/apache2/apache2.pid
+
+exec /usr/sbin/apache2ctl -D FOREGROUND

--- a/apache-php/5.6/files/application.dev.conf
+++ b/apache-php/5.6/files/application.dev.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    ServerName application.dev
+
+    DocumentRoot /home/docker/application/web
+    <Directory /home/docker/application/web>
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/application_error.log
+    LogLevel warn
+    CustomLog ${APACHE_LOG_DIR}/application_access.log combined
+</VirtualHost>

--- a/apache-php/7.0/Dockerfile
+++ b/apache-php/7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM akeneo/php:7.1
+FROM akeneo/php:7.0
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
 # Define "root" as current user
@@ -6,17 +6,17 @@ USER root
 
 # Install Apache + mod_php and some PHP extensions
 RUN apt-get update && \
-    apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php7.1 && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php7.0 && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
             /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
 
 # Configure PHP Apache
-RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php/7.1/apache2/php.ini && \
-    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/7.1/apache2/php.ini && \
-    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php/7.1/apache2/php.ini && \
-    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php/7.1/apache2/php.ini
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php/7.0/apache2/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/7.0/apache2/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php/7.0/apache2/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php/7.0/apache2/php.ini
 
 RUN phpdismod xdebug
 

--- a/apache-php/7.0/files/apache-foreground
+++ b/apache-php/7.0/files/apache-foreground
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+rm -f /var/run/apache2/apache2.pid
+
+exec /usr/sbin/apache2ctl -D FOREGROUND

--- a/apache-php/README.md
+++ b/apache-php/README.md
@@ -1,12 +1,20 @@
 # Apache and PHP on Docker
 
-[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-7.1)](https://travis-ci.org/akeneo/Dockerfiles/tree/php-7.1)
+[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg)](https://travis-ci.org/akeneo/Dockerfiles)
 
-This is a basic Docker environment for PHP development, based on [akeneo/php](https://hub.docker.com/r/akeneo/php). **This image does not contain Akeneo PIM**.
+This is a basic Docker environment for PHP development, based on [akeneo/php](https://hub.docker.com/r/akeneo/php).
 
-It provides a preconfigured Apache (2.4) + mod_php ( PHP 7.1 from [Sury repository](https://deb.sury.org/)) web server, based on Debian 9 (Stretch).
+It provides a preconfigured Apache (2.4) web server with `mod_php`.
 
-The environment comes with some PHP extensions: apcu, mcrypt, intl, mysql, curl, gd, mongo, soap, xml, zip, and xdebug (this last is deactivated by default, run `phpenmod xdebug` and restart Apache to enable it).
+The environment comes with some PHP extensions: apcu, mcrypt, intl, mysql, curl, gd, mongo, soap, xml, zip, and xdebug (this last one is deactivated by default, run `phpenmod xdebug` and restart Apache to enable it).
+
+**This image does not contain Akeneo PIM**.
+
+## Supported tags and respective `Dockerfile` links
+
+- `php-7.1`, `latest` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/apache-php/Dockerfile): The environment comes with Debian 9 (Stretch) with PHP 7.1 from [Sury repository](https://deb.sury.org/)
+- `php-7.0` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/apache-php/7.0/Dockerfile): The environment comes with Debian 9 (Stretch) with native PHP 7.0
+- `php-5.6` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/apache-php/5.6/Dockerfile): The environment comes with Debian 8 (Jessie) with native PHP 5.6
 
 ## How to use it
 
@@ -15,7 +23,7 @@ The environment comes with some PHP extensions: apcu, mcrypt, intl, mysql, curl,
 You can directly pull this image from [Docker hub](https://hub.docker.com/r/akeneo/apache-php/) by running:
 
 ```bash
-$ docker run --name akeneo-apache-php -p 8080:80 -d akeneo/apache-php:php-7.1
+$ docker run --name akeneo-apache-php -p 8080:80 -d akeneo/apache-php
 ```
 
 Access the URL `localhost:8080` with your web browser to check that the container works.
@@ -33,6 +41,8 @@ Then you can run a container like this:
 ```bash
 $ docker run --name akeneo-apache-php -p 8080:80 -d akeneo-apache-php
 ```
+
+Full documentation is accessible [here](https://github.com/akeneo/Dockerfiles#how-to-use-these-images)
 
 ## License
 

--- a/fpm/5.6/Dockerfile
+++ b/fpm/5.6/Dockerfile
@@ -1,0 +1,34 @@
+FROM akeneo/php:5.6
+MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
+
+# Define "root" as current user
+USER root
+
+# Install PHP FPM
+RUN apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install php5-fpm && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+            /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
+            /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
+
+# Configure PHP FPM
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php5/fpm/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php5/fpm/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php5/fpm/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php5/fpm/php.ini
+
+RUN sed -i "s/user = www-data/user = docker/" /etc/php5/fpm/pool.d/www.conf && \
+    sed -i "s/group = www-data/group = docker/" /etc/php5/fpm/pool.d/www.conf && \
+    sed -i "s/listen.owner = www-data/listen.owner = docker/" /etc/php5/fpm/pool.d/www.conf && \
+    sed -i "s/listen.group = www-data/listen.group = docker/" /etc/php5/fpm/pool.d/www.conf
+
+RUN php5dismod xdebug
+
+RUN sed -i "s/listen = .*/listen = 9001/" /etc/php5/fpm/pool.d/www.conf
+
+# Define "docker" as current user
+USER docker
+
+# Run FPM in foreground
+CMD ["sudo", "php5-fpm", "-F"]

--- a/fpm/7.0/Dockerfile
+++ b/fpm/7.0/Dockerfile
@@ -1,0 +1,34 @@
+FROM akeneo/php:7.0
+MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
+
+# Define "root" as current user
+USER root
+
+# Install PHP FPM
+RUN apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install php7.0-fpm && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+            /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
+            /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
+
+# Configure PHP FPM
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php/7.0/fpm/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/7.0/fpm/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php/7.0/fpm/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php/7.0/fpm/php.ini
+
+RUN sed -i "s/user = www-data/user = docker/" /etc/php/7.0/fpm/pool.d/www.conf && \
+    sed -i "s/group = www-data/group = docker/" /etc/php/7.0/fpm/pool.d/www.conf && \
+    sed -i "s/listen.owner = www-data/listen.owner = docker/" /etc/php/7.0/fpm/pool.d/www.conf && \
+    sed -i "s/listen.group = www-data/listen.group = docker/" /etc/php/7.0/fpm/pool.d/www.conf
+
+RUN phpdismod xdebug
+
+RUN mkdir -p /run/php && sed -i "s/listen = .*/listen = 9001/" /etc/php/7.0/fpm/pool.d/www.conf
+
+# Define "docker" as current user
+USER docker
+
+# Run FPM in foreground
+CMD ["sudo", "php-fpm7.0", "-F"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM akeneo/php:latest
+FROM akeneo/php:7.1
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
 # Define "root" as current user

--- a/fpm/README.md
+++ b/fpm/README.md
@@ -1,14 +1,22 @@
 # PHP FPM on Docker
 
-[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-7.1)](https://travis-ci.org/akeneo/Dockerfiles/tree/php-7.1)
+[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg)](https://travis-ci.org/akeneo/Dockerfiles)
 
-This is a basic Docker environment for PHP FPM development, based on [akeneo/php](https://hub.docker.com/r/akeneo/php). **This image does not contain Akeneo PIM**.
+This is a basic Docker environment for PHP FPM development, based on [akeneo/php](https://hub.docker.com/r/akeneo/php).
+
+It comes with the following PHP extensions: apcu, mcrypt, intl, mysql, curl, gd, mongo, soap, xml, zip and xdebug (this last one is deactivated by default, run `phpenmod xdebug` to enable it)
 
 It is intended to be used [httpd](https://hub.docker.com/_/httpd) with FCGI enable or [nginx](https://hub.docker.com/_/nginx).
 
-It comes with Debian 9 (Stretch) and PHP 7.1 (from [Sury repository](https://deb.sury.org/)), and some PHP extensions: fpm of course, but also apcu, mcrypt, intl, mysql, curl, gd, mongo, soap, xml, zip, and xdebug (this last is deactivated by default, run `phpenmod xdebug` to enable it).
-
 The PHP FPM daemon is configured with "docker" as user and group, and listens to the port `9001`.
+
+**This image does not contain Akeneo PIM**.
+
+## Supported tags and respective `Dockerfile` links
+
+- `php-7.1`, `latest` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/fpm/Dockerfile): The environment comes with Debian 9 (Stretch) with PHP 7.1 from [Sury repository](https://deb.sury.org/)
+- `php-7.0` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/fpm/7.0/Dockerfile): The environment comes with Debian 9 (Stretch) with native PHP 7.0
+- `php-5.6` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/fpm/5.6/Dockerfile): The environment comes with Debian 8 (Jessie) with native PHP 5.6
 
 ## How to use it
 
@@ -17,7 +25,7 @@ The PHP FPM daemon is configured with "docker" as user and group, and listens to
 You can directly pull this image from [Docker hub](https://hub.docker.com/r/akeneo/apache-php/) by running:
 
 ```bash
-$ docker run -d --name akeneo-fpm akeneo/fpm:php-7.1
+$ docker run -d --name akeneo-fpm akeneo/fpm
 ```
 
 ### From GitHub
@@ -33,6 +41,8 @@ Then you can run a container like this:
 ```bash
 $ docker run --name akeneo-fpm -d akeneo-fpm
 ```
+
+Full documentation is accessible [here](https://github.com/akeneo/Dockerfiles#how-to-use-these-images)
 
 ## License
 

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -1,0 +1,51 @@
+FROM debian:jessie-slim
+MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install some useful packages
+RUN apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
+        ca-certificates bash-completion less curl wget sudo \
+        mysql-client mongodb-clients ssh-client vim git imagemagick perceptualdiff && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+            /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
+            /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
+
+# Install PHP with some extensions
+RUN apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
+        php5-cli php5-apcu php5-curl php5-gd php5-imagick php5-intl php5-mongo php5-mcrypt php5-mysql php5-xdebug && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+            /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
+            /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
+
+# Configure PHP CLI
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php5/cli/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 2G/" /etc/php5/cli/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php5/cli/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php5/cli/php.ini
+
+RUN php5dismod xdebug
+
+# Add a "docker" user
+RUN useradd docker --shell /bin/bash --create-home \
+  && usermod --append --groups sudo docker \
+  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
+  && echo 'docker:secret' | chpasswd
+
+# Install composer
+RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN chmod +x /usr/local/bin/composer
+
+# Copy "entrypoint"
+COPY ./files/entrypoint.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+
+# Define "docker" as current user
+USER docker
+WORKDIR /home/docker/
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/php/5.6/files/entrypoint.sh
+++ b/php/5.6/files/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+XDEBUG_PATH="/etc/php5/mods-available/xdebug.ini"
+
+function execAsRoot {
+    sudo bash -c "$1"
+}
+
+function writeXdebugSetting {
+    execAsRoot "echo $1 >> ${XDEBUG_PATH}"
+}
+
+# checkOrWrite xdebugKey defaultValue providedValue
+function checkOrWriteXdebugSetting {
+   if [ -z "$3" ]; then
+       writeXdebugSetting "${1}=${2}"
+   else
+       writeXdebugSetting "${1}=${3}"
+   fi
+}
+
+writeXdebugSetting "xdebug.remote_enable=1"
+writeXdebugSetting "xdebug.max_nesting_level=500"
+writeXdebugSetting "xdebug.default_enable=1"
+
+checkOrWriteXdebugSetting "xdebug.idekey" "XDEBUG_IDE_KEY" "${PHP_XDEBUG_IDE_KEY}"
+
+if [ -z "${PHP_XDEBUG_REMOTE_HOST}" ]; then
+    writeXdebugSetting "xdebug.remote_connect_back=1"
+else
+    writeXdebugSetting "xdebug.remote_host=${PHP_XDEBUG_REMOTE_HOST}"
+fi
+
+if [ ! -z "${PHP_XDEBUG_ENABLED}" ]; then
+    if [ "${PHP_XDEBUG_ENABLED}" == "1" ]; then
+        execAsRoot "php5enmod xdebug"
+    elif [ "${PHP_XDEBUG_ENABLED}" == "0" ]; then
+        execAsRoot "php5dismod xdebug"
+    fi
+else
+    execAsRoot "php5dismod xdebug"
+fi
+
+eval "${@}"

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -1,0 +1,52 @@
+FROM debian:stretch-slim
+MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install some useful packages
+RUN apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
+        bash-completion ca-certificates curl git imagemagick less \
+        mongodb-clients mysql-client perceptualdiff procps ssh-client sudo vim wget && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+            /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
+            /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
+
+# Install PHP with some extensions
+RUN apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
+        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mbstring php7.0-mcrypt \
+        php7.0-mongo php7.0-mysql php7.0-soap php7.0-xdebug php7.0-xml php7.0-zip && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+            /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \
+            /usr/share/lintian/* /usr/share/locale/* /usr/share/man/*
+
+# Configure PHP CLI
+RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php/7.0/cli/php.ini && \
+    sed -i "s/memory_limit = .*/memory_limit = 2G/" /etc/php/7.0/cli/php.ini && \
+    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php/7.0/cli/php.ini && \
+    sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php/7.0/cli/php.ini
+
+RUN phpdismod xdebug
+
+# Add a "docker" user
+RUN useradd docker --shell /bin/bash --create-home \
+  && usermod --append --groups sudo docker \
+  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
+  && echo 'docker:secret' | chpasswd
+
+# Install composer
+RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN chmod +x /usr/local/bin/composer
+
+# Copy "entrypoint"
+COPY ./files/entrypoint.sh /usr/local/bin
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+
+# Define "docker" as current user
+USER docker
+WORKDIR /home/docker/
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/php/7.0/files/entrypoint.sh
+++ b/php/7.0/files/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+XDEBUG_PATH="/etc/php/7.0/mods-available/xdebug.ini"
+
+function execAsRoot {
+    sudo bash -c "$1"
+}
+
+function writeXdebugSetting {
+    execAsRoot "echo $1 >> ${XDEBUG_PATH}"
+}
+
+# checkOrWrite xdebugKey defaultValue providedValue
+function checkOrWriteXdebugSetting {
+   if [ -z "$3" ]; then
+       writeXdebugSetting "${1}=${2}"
+   else
+       writeXdebugSetting "${1}=${3}"
+   fi
+}
+
+writeXdebugSetting "xdebug.remote_enable=1"
+writeXdebugSetting "xdebug.max_nesting_level=500"
+writeXdebugSetting "xdebug.default_enable=1"
+
+checkOrWriteXdebugSetting "xdebug.idekey" "XDEBUG_IDE_KEY" "${PHP_XDEBUG_IDE_KEY}"
+
+if [ -z "${PHP_XDEBUG_REMOTE_HOST}" ]; then
+    writeXdebugSetting "xdebug.remote_connect_back=1"
+else
+    writeXdebugSetting "xdebug.remote_host=${PHP_XDEBUG_REMOTE_HOST}"
+fi
+
+if [ ! -z "${PHP_XDEBUG_ENABLED}" ]; then
+    if [ "${PHP_XDEBUG_ENABLED}" == "1" ]; then
+        execAsRoot "phpenmod xdebug"
+    elif [ "${PHP_XDEBUG_ENABLED}" == "0" ]; then
+        execAsRoot "phpdismod xdebug"
+    fi
+else
+    execAsRoot "phpdismod xdebug"
+fi
+
+eval "${@}"

--- a/php/README.md
+++ b/php/README.md
@@ -1,10 +1,18 @@
 # PHP CLI on Docker
 
-[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg?branch=php-7.1)](https://travis-ci.org/akeneo/Dockerfiles/tree/php-7.1)
+[![Build Status](https://travis-ci.org/akeneo/Dockerfiles.svg)](https://travis-ci.org/akeneo/Dockerfiles)
 
-This is a basic Docker environment for PHP development and testing, based on [debian:stretch-slim](https://hub.docker.com/_/debian/). **This image does not contain Akeneo PIM**.
+This is a basic Docker environment for PHP development and testing, based on [debian:stretch-slim or debian:jessie-slim](https://hub.docker.com/_/debian/), depending of PHP version.
 
-The environment comes with Debian 9 (Stretch) and PHP 7.1 (from [Sury repository](https://deb.sury.org/)), and some PHP extensions: apcu, mcrypt, intl, mysql, curl, gd, mongo, soap, xml, zip and xdebug (this last is deactivated by default, run `phpenmod xdebug` to enable it).
+It comes with the following PHP extensions: apcu, mcrypt, intl, mysql, curl, gd, mongo, soap, xml, zip and xdebug (this last one is deactivated by default, run `phpenmod xdebug` to enable it)
+
+**This image does not contain Akeneo PIM**.
+
+## Supported tags and respective `Dockerfile` links
+
+- `7.1`, `latest` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/php/Dockerfile): The environment comes with Debian 9 (Stretch) with PHP 7.1 from [Sury repository](https://deb.sury.org/)
+- `7.0` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/php/7.0/Dockerfile): The environment comes with Debian 9 (Stretch) with native PHP 7.0
+- `5.6` [(Dockerfile)](https://github.com/akeneo/Dockerfiles/blob/master/php/5.60/Dockerfile): The environment comes with Debian 8 (Jessie) with native PHP 5.6
 
 ## How to use it
 
@@ -13,7 +21,7 @@ The environment comes with Debian 9 (Stretch) and PHP 7.1 (from [Sury repository
 You can directly pull this image from [Docker hub](https://hub.docker.com/r/akeneo/apache-php/) by running:
 
 ```bash
-$ docker run -d --name akeneo-php akeneo/php:7.1
+$ docker run -d --name akeneo-php akeneo/php
 ```
 
 Access the URL `localhost:8080` with your web browser to check that the container works.
@@ -31,6 +39,8 @@ Then you can run a container like this:
 ```bash
 $ docker run --name akeneo-php -d php
 ```
+
+Full documentation is accessible [here](https://github.com/akeneo/Dockerfiles#how-to-use-these-images)
 
 ## License
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
 
-didFail=0
+didFail=1
 images=("php" "fpm" "apache-php")
+latestTag=$1
 
 cwd=$(pwd)
 for (( i=0; i<${#images[@]}; i++ ));
 do
-    cd ${cwd}/${images[i]}
-    docker build -t akeneo/${images[i]} .
+    if [ "$TAG" == "$latestTag" ]; then
+        path=${cwd}/${images[i]}
+    else
+        path=${cwd}/${images[i]}/${TAG}
+    fi
 
-    if ! docker inspect akeneo/${images[i]} &> /dev/null; then
-        echo $'\timage does not exist!'
+    cd ${path}
+    docker build -t akeneo/${images[i]}:${TAG} .
+
+    if docker inspect akeneo/${images[i]}:${TAG} &> /dev/null; then
+        didFail=0
+        continue
+    else
+        echo "akeneo/${images[i]}:${TAG} image does not exist!"
         didFail=1
         continue
     fi


### PR DESCRIPTION
## Description

This PR moves all the maintained images in the branch master, and use sub-folders for separating PHP versions. New Dockerfiles and there configuration files are just copy of the ones that were in separate branches, nothing more.

The Dockerfile of the latest version (currently PHP 7.1) is at the root of the image folder (for instance, `akeneo/php` is in `php/Dockerfile`) while previous versions are in subfolders (like `php/7.0/Dockerfile`).

This choice allows to have only one README.md file at the root of each image folder, which will be used to update Docker Hub main pages during automated builds.

### Note

This organization could changed in the future if the build of the images (and the update of the README) is fully done by the CI, not by Docker Hub anymore. Then the latest images could be in their own sub-folders like the previous versions.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | OK
| Changelog updated                 | OK
| Documentation                     | OK
| Fixed tickets                     | #284

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
