### PR TITLE
Issue 285: Enable APC for the CLI on PHP 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 2017-08-18
 
-### Enhancement
+### Enhancements
 
 - **Issue 284**: Move all images tags on master branch.
+- **Issue 285**: Enable APC for command line on PHP 7.1.
 
 ## 2017-07-17
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -32,6 +32,7 @@ RUN sed -i "s/;date.timezone =/date.timezone = Etc\/UTC/" /etc/php/7.1/cli/php.i
     sed -i "s/memory_limit = .*/memory_limit = 2G/" /etc/php/7.1/cli/php.ini && \
     sed -i "s/upload_max_filesize = .*/upload_max_filesize = 20M/" /etc/php/7.1/cli/php.ini && \
     sed -i "s/post_max_size = .*/post_max_size = 20M/" /etc/php/7.1/cli/php.ini
+COPY files/apcu.ini /etc/php/7.1/mods-available/apcu.ini
 
 RUN phpdismod xdebug
 

--- a/php/files/apcu.ini
+++ b/php/files/apcu.ini
@@ -1,0 +1,3 @@
+extension=apcu.so
+apc.enabled=1
+apc.enable_cli=1


### PR DESCRIPTION
## Description

On PHP 7.1, APC is by default disable for command line.

Howoever, since Akeneo migrates to Symfony 3.3, it has to be enable for command line.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #285

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
