### PR TITLE
Improve Docker performance on Mac

### DIFF
--- a/Docs/akeneo/docker-compose.mac.yml.dist
+++ b/Docs/akeneo/docker-compose.mac.yml.dist
@@ -1,0 +1,10 @@
+version: "2"
+
+services:
+  akeneo:
+    volumes:
+      - akeneo-sync:/srv/pim:rw
+
+volumes:
+  akeneo-sync:
+    external: true

--- a/Docs/akeneo/docker-sync.yml.dist
+++ b/Docs/akeneo/docker-sync.yml.dist
@@ -1,0 +1,12 @@
+version: "2"
+
+options:
+  compose-dev-file-path: 'docker-compose.mac.yml'
+
+syncs:
+  akeneo-sync:
+    src: './'
+    sync_host_port: 10872
+    sync_strategy: 'unison'
+    sync_userid: '1000'
+    sync_excludes: ['app/cache', 'app/logs', '.github', '.phpspec']


### PR DESCRIPTION
## Description

For having a better performance while developing on a Mac it's necessary to use docker-sync with the sync strategy unison.

http://docker-sync.io/
http://brewformulas.org/Unison

So the syncing and the docker container can be started by: docker-sync-stack start