### PR TITLE
Issue 303: Remove user "docker" as default user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2017-10-23
+
+### Enhancements
+
+- Remove user docker on php and apache-php 5.6
+
 ## 2017-10-10
 
 ### Enhancements

--- a/apache-php/5.6/Dockerfile
+++ b/apache-php/5.6/Dockerfile
@@ -1,9 +1,6 @@
 FROM akeneo/php:5.6
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
-# Define "root" as current user
-USER root
-
 # Install Apache + mod_php and some PHP extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php5 && \
@@ -34,8 +31,5 @@ EXPOSE 80 443
 COPY files/apache-foreground /usr/local/bin
 RUN  chmod +x /usr/local/bin/apache-foreground
 
-# Define "docker" as current user
-USER docker
-
 # Run apache in foreground
-CMD ["sudo", "/usr/local/bin/apache-foreground"]
+CMD ["/usr/local/bin/apache-foreground"]

--- a/fpm/5.6/Dockerfile
+++ b/fpm/5.6/Dockerfile
@@ -1,9 +1,6 @@
 FROM akeneo/php:5.6
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
-# Define "root" as current user
-USER root
-
 # Install PHP FPM
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install php5-fpm && \
@@ -27,8 +24,5 @@ RUN php5dismod xdebug
 
 RUN sed -i "s/listen = .*/listen = 9001/" /etc/php5/fpm/pool.d/www.conf
 
-# Define "docker" as current user
-USER docker
-
 # Run FPM in foreground
-CMD ["sudo", "php5-fpm", "-F"]
+CMD ["php5-fpm", "-F"]

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -45,7 +45,6 @@ COPY ./files/entrypoint.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/entrypoint.sh
 
 # Define "docker" as current user
-USER docker
 WORKDIR /home/docker/
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Description

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
- Bug fixes must be submitted against all needed PHP version in the same pull request.
-->

Remove user docker on image php and apache-php. 
Not compatible with CI and volume mount.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #303

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
