### PR TITLE
Issue 303: Remove the declaration of "docker" as default user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Remove user docker on php and apache-php 5.6
+- Remove user docker on php and apache-php 5.6/7.0/7.1
 
 ## 2017-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Remove user docker on php, fpm and apache-php 5.6/7.0/7.1
+- **Issue 303**: Remove user docker on php, fpm and apache-php (all tags).
 
 ## 2017-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Remove user docker on php and apache-php 5.6/7.0/7.1
+- Remove user docker on php, fpm and apache-php 5.6/7.0/7.1
 
 ## 2017-10-10
 

--- a/apache-php/7.0/Dockerfile
+++ b/apache-php/7.0/Dockerfile
@@ -1,9 +1,6 @@
 FROM akeneo/php:7.0
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
-# Define "root" as current user
-USER root
-
 # Install Apache + mod_php and some PHP extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php7.0 && \
@@ -34,8 +31,5 @@ EXPOSE 80 443
 COPY files/apache-foreground /usr/local/bin
 RUN  chmod +x /usr/local/bin/apache-foreground
 
-# Define "docker" as current user
-USER docker
-
 # Run apache in foreground
-CMD ["sudo", "/usr/local/bin/apache-foreground"]
+CMD ["/usr/local/bin/apache-foreground"]

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -1,9 +1,6 @@
 FROM akeneo/php:7.1
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
-# Define "root" as current user
-USER root
-
 # Install Apache + mod_php and some PHP extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install apache2 libapache2-mod-php7.1 && \
@@ -34,8 +31,5 @@ EXPOSE 80 443
 COPY files/apache-foreground /usr/local/bin
 RUN  chmod +x /usr/local/bin/apache-foreground
 
-# Define "docker" as current user
-USER docker
-
 # Run apache in foreground
-CMD ["sudo", "/usr/local/bin/apache-foreground"]
+CMD ["/usr/local/bin/apache-foreground"]

--- a/fpm/7.0/Dockerfile
+++ b/fpm/7.0/Dockerfile
@@ -1,9 +1,6 @@
 FROM akeneo/php:7.0
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
-# Define "root" as current user
-USER root
-
 # Install PHP FPM
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install php7.0-fpm && \
@@ -27,8 +24,5 @@ RUN phpdismod xdebug
 
 RUN mkdir -p /run/php && sed -i "s/listen = .*/listen = 9001/" /etc/php/7.0/fpm/pool.d/www.conf
 
-# Define "docker" as current user
-USER docker
-
 # Run FPM in foreground
-CMD ["sudo", "php-fpm7.0", "-F"]
+CMD ["php-fpm7.0", "-F"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,9 +1,6 @@
 FROM akeneo/php:7.1
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
-# Define "root" as current user
-USER root
-
 # Install PHP FPM
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install php7.1-fpm && \
@@ -27,8 +24,5 @@ RUN phpdismod xdebug
 
 RUN mkdir -p /run/php && sed -i "s/listen = .*/listen = 9001/" /etc/php/7.1/fpm/pool.d/www.conf
 
-# Define "docker" as current user
-USER docker
-
 # Run FPM in foreground
-CMD ["sudo", "php-fpm7.1", "-F"]
+CMD ["php-fpm7.1", "-F"]

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -46,7 +46,6 @@ COPY ./files/entrypoint.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/entrypoint.sh
 
 # Define "docker" as current user
-USER docker
 WORKDIR /home/docker/
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -51,7 +51,6 @@ COPY ./files/entrypoint.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/entrypoint.sh
 
 # Define "docker" as current user
-USER docker
 WORKDIR /home/docker/
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Description

Remove user docker on image php and apache-php.
Not compatible with CI and volume mount.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | Todo
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #303 

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
