### PR TITLE
Issue 305: Revert the removal of "sudo" in command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,23 @@
 
 ## 2017-10-23
 
-### Enhancements
+### Bug fix
+
+- **Issue 305**: Revert the removal of "sudo" in command, so the container can still be run by `docker` user.
+
+### Enhancement
 
 - **Issue 303**: Remove user docker on php, fpm and apache-php (all tags).
 
 ## 2017-10-10
 
-### Enhancements
+### Enhancement
 
 - **Issue 297**: Add make to all images.
 
 ## 2017-10-09
 
-### Enhancements
+### Enhancement
 
 - **Pull request 298**: Add PHP LDAP extension in all images. Thanks @jmleroux!
 

--- a/apache-php/5.6/Dockerfile
+++ b/apache-php/5.6/Dockerfile
@@ -32,4 +32,4 @@ COPY files/apache-foreground /usr/local/bin
 RUN  chmod +x /usr/local/bin/apache-foreground
 
 # Run apache in foreground
-CMD ["/usr/local/bin/apache-foreground"]
+CMD ["sudo", "/usr/local/bin/apache-foreground"]

--- a/apache-php/7.0/Dockerfile
+++ b/apache-php/7.0/Dockerfile
@@ -32,4 +32,4 @@ COPY files/apache-foreground /usr/local/bin
 RUN  chmod +x /usr/local/bin/apache-foreground
 
 # Run apache in foreground
-CMD ["/usr/local/bin/apache-foreground"]
+CMD ["sudo", "/usr/local/bin/apache-foreground"]

--- a/apache-php/Dockerfile
+++ b/apache-php/Dockerfile
@@ -32,4 +32,4 @@ COPY files/apache-foreground /usr/local/bin
 RUN  chmod +x /usr/local/bin/apache-foreground
 
 # Run apache in foreground
-CMD ["/usr/local/bin/apache-foreground"]
+CMD ["sudo", "/usr/local/bin/apache-foreground"]

--- a/fpm/5.6/Dockerfile
+++ b/fpm/5.6/Dockerfile
@@ -25,4 +25,4 @@ RUN php5dismod xdebug
 RUN sed -i "s/listen = .*/listen = 9001/" /etc/php5/fpm/pool.d/www.conf
 
 # Run FPM in foreground
-CMD ["php5-fpm", "-F"]
+CMD ["sudo", "php5-fpm", "-F"]

--- a/fpm/7.0/Dockerfile
+++ b/fpm/7.0/Dockerfile
@@ -25,4 +25,4 @@ RUN phpdismod xdebug
 RUN mkdir -p /run/php && sed -i "s/listen = .*/listen = 9001/" /etc/php/7.0/fpm/pool.d/www.conf
 
 # Run FPM in foreground
-CMD ["php-fpm7.0", "-F"]
+CMD ["sudo", "php-fpm7.0", "-F"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -25,4 +25,4 @@ RUN phpdismod xdebug
 RUN mkdir -p /run/php && sed -i "s/listen = .*/listen = 9001/" /etc/php/7.1/fpm/pool.d/www.conf
 
 # Run FPM in foreground
-CMD ["php-fpm7.1", "-F"]
+CMD ["sudo", "php-fpm7.1", "-F"]


### PR DESCRIPTION
## Description

We recently removed the step `USER: docker` in the Dockerfiles. This is good, but in the process we also removed the call to "sudo" in the `COMMAND` step of `fpm` and `apache-php` images.
As a result, the daemons can be launched only if container are instantiated with root as user.

This PR revert this "sudo" removal, so we can run the containers with `docker` as the user.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #305

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
