### PR TITLE
access composer and project binaries in PATH

### DIFF
--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -47,4 +47,6 @@ RUN chmod a+x /usr/local/bin/entrypoint.sh
 # Define "docker" as current user
 WORKDIR /home/docker/
 
+ENV PATH=bin:vendor/bin:$PATH
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -48,4 +48,6 @@ RUN chmod a+x /usr/local/bin/entrypoint.sh
 # Define "docker" as current user
 WORKDIR /home/docker/
 
+ENV PATH=bin:vendor/bin:$PATH
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -53,4 +53,6 @@ RUN chmod a+x /usr/local/bin/entrypoint.sh
 # Define "docker" as current user
 WORKDIR /home/docker/
 
+ENV PATH=bin:vendor/bin:$PATH
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Eases the writing of common CLI commands such as `vendor/bin/behat` becoming `behat`.