### PR TITLE
Issue 323: Fix Timezone and memory limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2018-08-18
+
+### Bug fix
+
+- **Issue 323**: Set timezone to `UTC` and increase `post_max_size` so it is larger than `upload_max_filesize`.
+
 ## 2018-02-23
 
 ### Enhancement

--- a/php/5.6/files/akeneo.ini
+++ b/php/5.6/files/akeneo.ini
@@ -1,8 +1,8 @@
 display_errors = On
 error_reporting = E_ALL
 
-date.timezone = Etc/UTC
+date.timezone = UTC
 
 memory_limit = 2G
-upload_max_filesize = 20M
-post_max_size = 20M
+upload_max_filesize = 32M
+post_max_size = 64M

--- a/php/7.0/files/akeneo.ini
+++ b/php/7.0/files/akeneo.ini
@@ -1,8 +1,8 @@
 display_errors = On
 error_reporting = E_ALL
 
-date.timezone = Etc/UTC
+date.timezone = UTC
 
 memory_limit = 2G
-upload_max_filesize = 20M
-post_max_size = 20M
+upload_max_filesize = 32M
+post_max_size = 64M

--- a/php/7.1/files/akeneo.ini
+++ b/php/7.1/files/akeneo.ini
@@ -1,11 +1,11 @@
 display_errors = On
 error_reporting = E_ALL
 
-date.timezone = Etc/UTC
+date.timezone = UTC
 
 memory_limit = 2G
-upload_max_filesize = 20M
-post_max_size = 20M
+upload_max_filesize = 32M
+post_max_size = 64M
 
 apc.enabled=1
 apc.enable_cli=1

--- a/php/7.2/files/akeneo.ini
+++ b/php/7.2/files/akeneo.ini
@@ -1,11 +1,11 @@
 display_errors = On
 error_reporting = E_ALL
 
-date.timezone = Etc/UTC
+date.timezone = UTC
 
 memory_limit = 2G
-upload_max_filesize = 20M
-post_max_size = 20M
+upload_max_filesize = 32M
+post_max_size = 64M
 
 apc.enabled=1
 apc.enable_cli=1

--- a/tests/php/common/datetime_zone.sh
+++ b/tests/php/common/datetime_zone.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-echo "Default timezone should be Etc/UTC"
+echo "Default timezone should be UTC"
 
 DATETIME_ZONE=$(php -i | grep date.timezone)
 
-if [ "date.timezone => Etc/UTC => Etc/UTC" != "$DATETIME_ZONE" ]; then
+if [ "date.timezone => UTC => UTC" != "$DATETIME_ZONE" ]; then
     echo "Failure"
     exit 1
 fi

--- a/tests/php/common/post_max_size.sh
+++ b/tests/php/common/post_max_size.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-echo "Maximum size of POST data that PHP will accept should be 20 megabytes"
+echo "Maximum size of POST data that PHP will accept should be 64 megabytes"
 
 POST_MAX_SIZE=$(php -i | grep post_max_size)
 
-if [ "post_max_size => 20M => 20M" != "$POST_MAX_SIZE" ]; then
+if [ "post_max_size => 64M => 64M" != "$POST_MAX_SIZE" ]; then
     echo "Failure"
     exit 1
 fi

--- a/tests/php/common/upload_max_filesize.sh
+++ b/tests/php/common/upload_max_filesize.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-echo "Maximum allowed size for uploaded files should be 20 megabytes"
+echo "Maximum allowed size for uploaded files should be 32 megabytes"
 
 UPLOAD_MAX_FILE_SIZE=$(php -i | grep upload_max_filesize)
 
-if [ "upload_max_filesize => 20M => 20M" != "$UPLOAD_MAX_FILE_SIZE" ]; then
+if [ "upload_max_filesize => 32M => 32M" != "$UPLOAD_MAX_FILE_SIZE" ]; then
     echo "Failure"
     exit 1
 fi


### PR DESCRIPTION
## Description

This PR fixes two configuration issues, revealed when trying to install the latest Symfony 4 skeleton.

- Timezone was previously `Etc/UTC`. This is a [deprecated timezone](https://secure.php.net/manual/en/timezones.others.php), the correct one is simply `UTC`.
- `post_max_size` must be larger than `upload_max_filesize`, so they have been respectively increased to 64M and 32M.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | OK
| Changelog updated                 | OK
| Documentation                     | -
| Fixed tickets                     | #323

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
