### PR TITLE
PIM-7903: remove mbstring extension for PHP 7.0 and 7.1

### DIFF
--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 # Install PHP with some extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mbstring php7.0-mcrypt \
+        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mcrypt \
         php7.0-mongo php7.0-mysql php7.0-soap php7.0-xdebug php7.0-xml php7.0-zip php7.0-ldap && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -20,7 +20,7 @@ COPY files/sury.list /etc/apt/sources.list.d/sury.list
 # Install PHP with some extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        php7.1-cli php7.1-apcu php7.1-mbstring php7.1-curl php7.1-gd php7.1-imagick php7.1-intl php7.1-bcmath \
+        php7.1-cli php7.1-apcu php7.1-curl php7.1-gd php7.1-imagick php7.1-intl php7.1-bcmath \
         php7.1-mcrypt php7.1-mongodb php7.1-mysql php7.1-soap php7.1-xdebug php7.1-xml php7.1-zip php7.1-ldap && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
## Description

mbstring extension is not in the PIM requirements

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | Todo
| Documentation                     | -
| Fixed tickets                     | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
