### PR TITLE
Revert removing of php7.0-mbstring and php7.1-mbstring

### DIFF
--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 # Install PHP with some extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mcrypt \
+        php7.0-cli php7.0-apcu php7.0-curl php7.0-gd php7.0-imagick php7.0-intl php7.0-mbstring php7.0-mcrypt \
         php7.0-mongo php7.0-mysql php7.0-soap php7.0-xdebug php7.0-xml php7.0-zip php7.0-ldap && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -20,7 +20,7 @@ COPY files/sury.list /etc/apt/sources.list.d/sury.list
 # Install PHP with some extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        php7.1-cli php7.1-apcu php7.1-curl php7.1-gd php7.1-imagick php7.1-intl php7.1-bcmath \
+        php7.1-cli php7.1-apcu php7.0-mbstring php7.1-curl php7.1-gd php7.1-imagick php7.1-intl php7.1-bcmath \
         php7.1-mcrypt php7.1-mongodb php7.1-mysql php7.1-soap php7.1-xdebug php7.1-xml php7.1-zip php7.1-ldap && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
## Description

There was a bug on the PIM:
mb_string was used somewhere on the PIM but not required. So people install without mb_string and had a bug.
What was did is to remove the use of mb_string in the PIM and remove the extension from docker/ansible.

But it seems that behat need mb_string.

[2.3 ?]$ docker-compose exec fpm composer install --prefer-dist

Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for behat/behat 3.4.3 -> satisfiable by behat/behat[v3.4.3].
    - behat/behat v3.4.3 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
  Problem 2
    - Installation request for phpunit/phpunit 6.5.3 -> satisfiable by phpunit/phpunit[6.5.3].
    - phpunit/phpunit 6.5.3 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
  Problem 3
    - behat/behat v3.4.3 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
    - sensiolabs/behat-page-object-extension v2.1.0 requires behat/behat ^3.0.6 -> satisfiable by behat/behat[v3.4.3].
    - Installation request for sensiolabs/behat-page-object-extension 2.1.0 -> satisfiable by sensiolabs/behat-page-object-extension[v2.1.0].

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | Todo
| Changelog updated                 | Todo
| Documentation                     | -
| Fixed tickets                     | #... <!-- #-prefixed issue number(s), if any -->

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
