### PR TITLE
Fix using of php7.1-mbstring

### DIFF
--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -20,7 +20,7 @@ COPY files/sury.list /etc/apt/sources.list.d/sury.list
 # Install PHP with some extensions
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
-        php7.1-cli php7.1-apcu php7.0-mbstring php7.1-curl php7.1-gd php7.1-imagick php7.1-intl php7.1-bcmath \
+        php7.1-cli php7.1-apcu php7.1-mbstring php7.1-curl php7.1-gd php7.1-imagick php7.1-intl php7.1-bcmath \
         php7.1-mcrypt php7.1-mongodb php7.1-mysql php7.1-soap php7.1-xdebug php7.1-xml php7.1-zip php7.1-ldap && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
## Description

php7.0-mbstring was loaded in php 7.1 image.

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
- Bug fixes must be submitted against all needed PHP version in the same pull request.
-->

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | Todo
| Changelog updated                 | Todo
| Documentation                     | -
| Fixed tickets                     | #... <!-- #-prefixed issue number(s), if any -->

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
