### PR TITLE
TIP-1018 removes unused SOAP dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2018-08-18
 
+### Enhancement
+
+- **TIP 1018**: Removes unused SOAP extension
+
+## 2018-08-18
+
 ### Bug fix
 
 - **Issue 323**: Set timezone to `UTC` and increase `post_max_size` so it is larger than `upload_max_filesize`.

--- a/fpm/7.2/README.md
+++ b/fpm/7.2/README.md
@@ -4,7 +4,7 @@
 
 This Dockerfile is a basic environment for PHP development, providing a preconfigured FastCGI Process Manager (FPM).
 
-It is based on [akeneo/php](https://hub.docker.com/r/akeneo/php), and comes with the following PHP extensions: apcu, curl, gd, intl, mysql, soap, xml, zip, and xdebug (this last one is deactivated by default, run `phpenmod xdebug` and restart Apache to enable it).
+It is based on [akeneo/php](https://hub.docker.com/r/akeneo/php), and comes with the following PHP extensions: apcu, curl, gd, intl, mysql, xml, zip, and xdebug (this last one is deactivated by default, run `phpenmod xdebug` and restart Apache to enable it).
 
 Extensions mcrypt and mongo are also present on PHP 7.1 and previous versions.
 

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -21,7 +21,7 @@ COPY files/sury.list /etc/apt/sources.list.d/sury.list
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
         php7.2-cli php7.2-apcu php7.2-mbstring php7.2-curl php7.2-gd php7.2-imagick php7.2-intl php7.2-bcmath \
-        php7.2-mysql php7.2-soap php7.2-xdebug php7.2-xml php7.2-zip php7.2-ldap && \
+        php7.2-mysql php7.2-xdebug php7.2-xml php7.2-zip php7.2-ldap && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \

--- a/php/7.2/README.md
+++ b/php/7.2/README.md
@@ -4,7 +4,7 @@
 
 This Dockerfile is a basic environment for PHP development and testing, based on [debian:stretch-slim or debian:jessie-slim](https://hub.docker.com/_/debian/), depending of PHP version (see the supported tag list below).
 
-It comes with the following PHP extensions: apcu, curl, gd, intl, mysql, soap, xml, zip and xdebug (this last one is deactivated by default, run `phpenmod xdebug` to enable it).
+It comes with the following PHP extensions: apcu, curl, gd, intl, mysql, xml, zip and xdebug (this last one is deactivated by default, run `phpenmod xdebug` to enable it).
 
 Extensions mcrypt and mongo are also present on PHP 7.1 and previous versions.
 


### PR DESCRIPTION
## Description
 Remove unused SOAP dependency from docker image for PHP 7.2+

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | -
| Documentation                     | -
| Fixed tickets                     | #... <!-- #-prefixed issue number(s), if any -->

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
