### PR TITLE
PIM-8960: Add ghost script install in php container

### DIFF
--- a/php/7.3/Dockerfile
+++ b/php/7.3/Dockerfile
@@ -7,7 +7,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
         apt-transport-https bash-completion ca-certificates curl git gnupg imagemagick \
-        less make mysql-client perceptualdiff procps ssh-client sudo unzip vim wget && \
+        less make mysql-client perceptualdiff procps ssh-client sudo unzip vim wget \
+        ghostscript && \
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf  /var/lib/apt/lists/* /tmp/* /var/tmp/* \
             /usr/share/doc/* /usr/share/groff/* /usr/share/info/* /usr/share/linda/* \


### PR DESCRIPTION
## Description

Adds the "ghostscript" library in the PHP container that is needed for the generation of thumbnails for assets referencing PDFs via URL.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | Todo
| Changelog updated                 | Todo
| Documentation                     | -
| Fixed tickets                     | #... <!-- #-prefixed issue number(s), if any -->

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
