### PR TITLE
#354 - Remove the existing node user and recreate with passed-in ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2020-02-28
+- **Issue 354**: Allow `node` user of `akeneo/node:10` image to be given an id other than `1000`
+
 ## 2020-02-21
 
 ### Bug fix

--- a/node/10/Dockerfile
+++ b/node/10/Dockerfile
@@ -4,9 +4,7 @@ MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 ARG USER_ID=1000
 
 # Delete and recreate node user with the provided id
-RUN userdel --remove node \
-    && groupadd -g $USER_ID node \
-    && useradd -lms /bin/bash -u $USER_ID node -g node
+RUN usermod --uid ${USER_ID} node && groupmod --gid ${USER_ID} node
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others).
 # Note: this installs the necessary libs to make work the bundled version of Chromium that Puppeteer installs.

--- a/node/10/Dockerfile
+++ b/node/10/Dockerfile
@@ -1,6 +1,12 @@
 FROM node:10-slim
 MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
+ARG USER_ID=1000
+
+RUN userdel --remove node \
+    && groupadd -g $USER_ID node \
+    && useradd -lms /bin/bash -u $USER_ID node -g node
+
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others).
 # Note: this installs the necessary libs to make work the bundled version of Chromium that Puppeteer installs.
 #

--- a/node/10/Dockerfile
+++ b/node/10/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
 ARG USER_ID=1000
 
+# Delete and recreate node user with the provided id
 RUN userdel --remove node \
     && groupadd -g $USER_ID node \
     && useradd -lms /bin/bash -u $USER_ID node -g node

--- a/node/10/Dockerfile
+++ b/node/10/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Damien Carcel <damien.carcel@akeneo.com>
 
 ARG USER_ID=1000
 
-# Delete and recreate node user with the provided id
+# Change the id of the node user to the provided value
 RUN usermod --uid ${USER_ID} node && groupmod --gid ${USER_ID} node
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others).


### PR DESCRIPTION
## Description
This is a fix for issue #354 - allowing a user id to be passed as an argument to the node container so that the `node` user is not restricted to the default of `1000` (which is retained as a default)
<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
- Bug fixes must be submitted against all needed PHP version in the same pull request.
- Please link your PR to its related issue.
-->

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
