### PR TITLE
RAC: add node v14 image

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,6 +14,8 @@ jobs:
                       images: "node"
                     - version: "12"
                       images: "node"
+                    - version: "14"
+                      images: "node"
         steps:
             -   uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2022-05-05
+- Added Node 14 image
+
 ## 2020-02-28
 - **Issue 354**: Allow `node` user of `akeneo/node:10` image to be given an id other than `1000`
 
@@ -269,7 +272,7 @@
 ### Bug fix
 
 - **Issue 75**: Allow to properly restart apache container by removing `/var/run/apache2/apache2.pid` in
-    `carcel/apache-php` image entry point. 
+    `carcel/apache-php` image entry point.
 
 ### Enhancements
 
@@ -283,7 +286,7 @@
 - **Issue 88**: Allow user to config Xdebug from environment variables.
 - **Issue 89**: Introduce `php-7.1` branch containing PHP 7.1 based images.
     PHP 7.1 packages are provided by [Sury](https://packages.sury.org//) repositories. Master is updated to PHP 7.1 too.
-    
+
 ## 2016-12-05
 
 ### Enhancement
@@ -358,7 +361,7 @@
     Master contains the same PHP 7.0 images.
     Original PHP 5.6 images (Debian Jessie native packages) are now in the `php-5.6` branch.
     All files used by dockerfiles are now placed in a `files` subfolder.
-    
+
 ## 2016-10-07
 
 ### Enhancement

--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ All PHP and FPM images are available as follow:
 | 7.3         | Debian 9 "Stretch" with packages coming from [Ondřej Surý repository](https://deb.sury.org/) | akeneo/php:7.3     |
 |             |                                                                                              | akeneo/fpm:php-7.3 |
 
-And for Node images:
-
-| Node version | Based on                             | Corresponding tags |
-|--------------|--------------------------------------|--------------------|
-| 10           | Official Docker image `node:10-slim` | akeneo/node:10     |
-
 For all images, tag `latest` is identical to the one corresponding to the most recent language version.
 
 Akeneo 3.x is to be used only with PHP 7.2 (or higher), with php-fpm and Apache 2.4 with FCGI.
 Akeneo 4.0 comes with its own Docker images and does not use this repository anymore.
+
+And for Node images:
+
+| Node version | Yarn version | Based on                                   | Corresponding tags |
+|--------------|--------------|--------------------------------------------|--------------------|
+| 10           | 1.13         | Official Docker image `debian:buster-slim` | akeneo/node:10     |
+| 12           | 1.22         | Official Docker image `debian:buster-slim` | akeneo/node:12     |
+| 14           | 1.22         | Official Docker image `debian:buster-slim` | akeneo/node:14     |
 
 ## How to use these images
 

--- a/node/14/Dockerfile
+++ b/node/14/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:buster-slim
-MAINTAINER Steven Vaidie <steven.vaidie@akeneo.com> # TODO remove (deprecated)
 
 RUN groupadd --gid 1000 node \
     && useradd --uid 1000 --gid node --shell /bin/bash --create-home node

--- a/node/14/Dockerfile
+++ b/node/14/Dockerfile
@@ -1,0 +1,55 @@
+FROM debian:buster-slim
+MAINTAINER Steven Vaidie <steven.vaidie@akeneo.com> # TODO remove (deprecated)
+
+RUN groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+RUN echo 'path-exclude=/usr/share/man/*' > /etc/dpkg/dpkg.cfg.d/path_exclusions && \
+    echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/path_exclusions && \
+    apt-get update && \
+    apt-get --no-install-recommends --no-install-suggests -y -q install \
+    wget apt-transport-https ca-certificates gnupg && \
+    apt-get clean && apt-get --yes --quiet autoremove --purge && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# NodeJS 14 and Yarn
+RUN sh -c 'wget -q -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -' && \
+    sh -c 'echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list' && \
+    sh -c 'echo "deb-src https://deb.nodesource.com/node_14.x buster main" >> /etc/apt/sources.list.d/nodesource.list' && \
+    sh -c 'wget -q -O - https://dl.yarnpkg.com/debian/pubkey.gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -' && \
+    sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list' && \
+    apt-get update && \
+    apt-get install -y nodejs yarn \
+    && apt-get clean && apt-get -y -q autoremove --purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others).
+# Note: this installs the necessary libs to make work the bundled version of Chromium that Puppeteer installs.
+#
+# Puppeter is installed as a JS dependency in the PIM. It is not needed directly in the image.
+# @see https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+RUN apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y -q install \
+            ca-certificates fonts-liberation gconf-service gnupg libasound2 libatk1.0-0 libcairo2 libcups2 \
+            libdbus-1-3 libexpat1 libfontconfig1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
+            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+            libappindicator1 libnss3 lsb-release wget xdg-utils \
+    && wget https://dl-ssl.google.com/linux/linux_signing_key.pub \
+    && apt-key add linux_signing_key.pub \
+    && rm linux_signing_key.pub \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests --yes --quiet install \
+            google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    && apt-get clean && apt-get --yes --quiet autoremove --purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.4/dumb-init_1.2.4_x86_64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+USER node
+
+ENTRYPOINT ["dumb-init", "--"]

--- a/tests/node/run_image_tests.sh
+++ b/tests/node/run_image_tests.sh
@@ -8,11 +8,11 @@ IMAGE_TAG=$1
 CURRENT_DIR=$(dirname $(readlink -f $0))
 
 for TEST in $(ls -1 ${CURRENT_DIR}/common/*.sh 2> /dev/null || true); do
-    docker run -i -t --rm -u node -v ${TEST}:/home/docker/test.sh akeneo/node:${IMAGE_TAG} bash test.sh || DID_FAIL=1
+    docker run -i -t --rm -v ${TEST}:/home/docker/test.sh akeneo/node:${IMAGE_TAG} bash test.sh || DID_FAIL=1
 done
 
 for TEST in $(ls -1 ${CURRENT_DIR}/${IMAGE_TAG}/*.sh 2> /dev/null || true); do
-    docker run -i -t --rm -u node -v ${TEST}:/home/docker/test.sh akeneo/node:${IMAGE_TAG} bash test.sh || DID_FAIL=1
+    docker run -i -t --rm -v ${TEST}:/home/docker/test.sh akeneo/node:${IMAGE_TAG} bash test.sh || DID_FAIL=1
 done
 
 test "0" -ne "$DID_FAIL" && exit 1


### PR DESCRIPTION
## Description

As node 12 is now deprecated since [30th April 2022](https://endoflife.date/nodejs). I submit a PR to add a brand new image including node 14.

Results of the build:

```bash
$ docker run --rm akeneo/node:14 node --version
v14.19.2

$ docker run --rm akeneo/node:14 yarn --version
1.22.18
````

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
- Bug fixes must be submitted against all needed PHP version in the same pull request.
- Please link your PR to its related issue.
-->

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added tests                       | -
| Changelog updated                 | OK
| Documentation                     | OK

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
